### PR TITLE
[INTERNAL] package.json: Define files to publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,12 @@
 		"release-note": "git-chglog -c .chglog/release-config.yml v$npm_package_version",
 		"report-coveralls": "nyc report --reporter=text-lcov | coveralls"
 	},
+	"files": [
+		"index.js",
+		"CONTRIBUTING.md",
+		"jsdoc.json",
+		"lib/**"
+	],
 	"ava": {
 		"files": [
 			"test/lib/**/*.js"


### PR DESCRIPTION
### Package sizes (tested by executing `npm pack`):

**Before**
npm notice package size:  29.0 kB                                 
npm notice unpacked size: 107.2 kB 

**After**
npm notice package size:  17.8 kB                                 
npm notice unpacked size: 64.2 kB 


**=> Reduction of ~40%**


### New package content:  
```
❯ tree                                                       
.
├── CHANGELOG.md
├── CONTRIBUTING.md
├── LICENSE.txt
├── NOTICE.txt
├── README.md
├── index.js
├── jsdoc.json
├── lib
│   ├── AbstractReader.js
│   ├── AbstractReaderWriter.js
│   ├── DuplexCollection.js
│   ├── ReaderCollection.js
│   ├── ReaderCollectionPrioritized.js
│   ├── Resource.js
│   ├── adapters
│   │   ├── AbstractAdapter.js
│   │   ├── FileSystem.js
│   │   └── Memory.js
│   ├── fsInterface.js
│   ├── resourceFactory.js
│   └── tracing
│       ├── Trace.js
│       └── traceSummary.js
└── package.json
```