### PR TITLE
[BREAKING] index.js export: Remove top-level access to adapters

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,9 +14,6 @@ module.exports = {
 		FileSystem: require("./lib/adapters/FileSystem"),
 		Memory: require("./lib/adapters/Memory")
 	},
-	AbstractAdapter: require("./lib/adapters/AbstractAdapter"), // TODO 1.0 remove
-	FileSystem: require("./lib/adapters/FileSystem"), // TODO 1.0 remove
-	Memory: require("./lib/adapters/Memory"), // TODO 1.0 remove
 	AbstractReader: require("./lib/AbstractReader"),
 	AbstractReaderWriter: require("./lib/AbstractReaderWriter"),
 	DuplexCollection: require("./lib/DuplexCollection"),

--- a/test/lib/fsInterface.js
+++ b/test/lib/fsInterface.js
@@ -5,8 +5,8 @@ const path = require("path");
 const fs = require("fs");
 const ui5Fs = require("../../");
 const fsInterface = ui5Fs.fsInterface;
-const MemAdapter = ui5Fs.Memory;
-const FsAdapter = ui5Fs.FileSystem;
+const MemAdapter = ui5Fs.adapters.Memory;
+const FsAdapter = ui5Fs.adapters.FileSystem;
 const Resource = ui5Fs.Resource;
 
 const assertReadFile = (t, readFile, basepath, filepath) => {

--- a/test/lib/glob.js
+++ b/test/lib/glob.js
@@ -1,7 +1,7 @@
 const {test} = require("ava");
 const ui5Fs = require("../../");
-const FsAdapter = ui5Fs.FileSystem;
-const MemAdapter = ui5Fs.Memory;
+const FsAdapter = ui5Fs.adapters.FileSystem;
+const MemAdapter = ui5Fs.adapters.Memory;
 
 // Create readerWriter before running tests
 test.beforeEach((t) => {


### PR DESCRIPTION
BREAKING CHANGE: Adapters "AbstractAdapter", "FileSystem" and "Memory" used to be accessible via the top-level export of index.js (example: require("@ui5/project").FileSystem). This is no longer possible. Adapters are now grouped in the top-level object "adapters" and can be accessed from there (example: require("@ui5/project").adapters.FileSystem).