### PR TITLE
[INTERNAL] FS Adapter: Stop passing byGlob options directly to globby

### DIFF
--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -35,11 +35,12 @@ class AbstractAdapter extends AbstractReaderWriter {
 	 * @private
 	 * @param {string|Array} virPattern GLOB pattern as string or an array of
 	 *         glob patterns for virtual directory structure
-	 * @param {Object} options GLOB options
+	 * @param {Object} [options={}] GLOB options
+	 * @param {boolean} [options.nodir=true] Do not match directories
 	 * @param {module:@ui5/fs.tracing.Trace} trace Trace instance
 	 * @returns {Promise<module:@ui5/fs.Resource[]>} Promise resolving to list of resources
 	 */
-	_byGlob(virPattern, options, trace) {
+	_byGlob(virPattern, options = {nodir: true}, trace) {
 		if (!(virPattern instanceof Array)) {
 			virPattern = [virPattern];
 		}

--- a/lib/adapters/FileSystem.js
+++ b/lib/adapters/FileSystem.js
@@ -2,8 +2,6 @@ const log = require("@ui5/logger").getLogger("resources:adapters:FileSystem");
 const path = require("path");
 const fs = require("graceful-fs");
 const glob = require("globby");
-const defaults = require("defaults");
-const clone = require("clone");
 const makeDir = require("make-dir");
 const Resource = require("../Resource");
 const AbstractAdapter = require("./AbstractAdapter");
@@ -33,16 +31,18 @@ class FileSystem extends AbstractAdapter {
 	 *
 	 * @private
 	 * @param {Array} patterns Array of GLOB patterns
-	 * @param {Object} [options] GLOB options
+	 * @param {Object} [options={}] GLOB options
+	 * @param {boolean} [options.nodir=true] Do not match directories
 	 * @param {module:@ui5/fs.tracing.Trace} trace Trace instance
 	 * @returns {Promise<module:@ui5/fs.Resource[]>} Promise resolving to list of resources
 	 */
-	_runGlob(patterns, options, trace) {
+	_runGlob(patterns, options = {nodir: true}, trace) {
 		return new Promise((resolve, reject) => {
-			const opt = defaults(clone(options), { // Clone needed to prevent side effects
-				cwd: this._fsBasePath,			 // (todo: maybe make this a module itself)
-				dot: true
-			});
+			const opt = {
+				cwd: this._fsBasePath,
+				dot: true,
+				nodir: options.nodir
+			};
 
 			trace.globCall();
 			glob(patterns, opt).then((matches) => {

--- a/lib/adapters/Memory.js
+++ b/lib/adapters/Memory.js
@@ -29,11 +29,12 @@ class Memory extends AbstractAdapter {
 	 *
 	 * @private
 	 * @param {Array} patterns array of GLOB patterns
-	 * @param {Object} [options] GLOB options
+	 * @param {Object} [options={}] GLOB options
+	 * @param {boolean} [options.nodir=true] Do not match directories
 	 * @param {module:@ui5/fs.tracing.Trace} trace Trace instance
 	 * @returns {Promise<module:@ui5/fs.Resource[]>} Promise resolving to list of resources
 	 */
-	_runGlob(patterns, options, trace) {
+	_runGlob(patterns, options = {nodir: true}, trace) {
 		if (patterns[0] === "" && !options.nodir) { // Match virtual root directory
 			return Promise.resolve([
 				new Resource({

--- a/package-lock.json
+++ b/package-lock.json
@@ -2085,21 +2085,6 @@
 			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
 			"dev": true
 		},
-		"defaults": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.3.tgz",
-			"integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
-			"requires": {
-				"clone": "^1.0.2"
-			},
-			"dependencies": {
-				"clone": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
-					"integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
-				}
-			}
-		},
 		"define-property": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
@@ -2906,8 +2891,7 @@
 					"version": "2.1.1",
 					"resolved": false,
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2931,15 +2915,13 @@
 					"version": "1.0.0",
 					"resolved": false,
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"resolved": false,
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2956,22 +2938,19 @@
 					"version": "1.1.0",
 					"resolved": false,
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": false,
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": false,
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3102,8 +3081,7 @@
 					"version": "2.0.3",
 					"resolved": false,
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3117,7 +3095,6 @@
 					"resolved": false,
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3134,7 +3111,6 @@
 					"resolved": false,
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3143,15 +3119,13 @@
 					"version": "0.0.8",
 					"resolved": false,
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"resolved": false,
 					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3172,7 +3146,6 @@
 					"resolved": false,
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3261,8 +3234,7 @@
 					"version": "1.0.1",
 					"resolved": false,
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3276,7 +3248,6 @@
 					"resolved": false,
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3372,8 +3343,7 @@
 					"version": "5.1.1",
 					"resolved": false,
 					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3415,7 +3385,6 @@
 					"resolved": false,
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3437,7 +3406,6 @@
 					"resolved": false,
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3486,15 +3454,13 @@
 					"version": "1.0.2",
 					"resolved": false,
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"resolved": false,
 					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -5068,7 +5034,6 @@
 					"resolved": false,
 					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -5438,8 +5403,7 @@
 					"version": "1.1.6",
 					"resolved": false,
 					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
@@ -5535,7 +5499,6 @@
 					"resolved": false,
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -5588,8 +5551,7 @@
 					"version": "1.0.1",
 					"resolved": false,
 					"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
@@ -5892,8 +5854,7 @@
 					"version": "1.6.1",
 					"resolved": false,
 					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
 	"dependencies": {
 		"@ui5/logger": "^0.2.2",
 		"clone": "^2.1.0",
-		"defaults": "^1.0.3",
 		"globby": "^7.1.1",
 		"graceful-fs": "^4.1.15",
 		"make-dir": "^1.1.0",


### PR DESCRIPTION
Currently the only possible option should be "nodir".

This resolves possible inconsistencies when calling FileSystem and
Memory adapters with identical options containing more than "nodir".
Before, FS passed options to the glob module as a whole while Memory
only passed certain options.

This will also make it easier to upgrade to globby 8.x (see https://github.com/SAP/ui5-fs/pull/67)