### PR TITLE
[DEPENDENCY] Pin dir-glob to v2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2891,8 +2891,7 @@
 					"version": "2.1.1",
 					"resolved": false,
 					"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"aproba": {
 					"version": "1.2.0",
@@ -2916,15 +2915,13 @@
 					"version": "1.0.0",
 					"resolved": false,
 					"integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"brace-expansion": {
 					"version": "1.1.11",
 					"resolved": false,
 					"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"balanced-match": "^1.0.0",
 						"concat-map": "0.0.1"
@@ -2941,22 +2938,19 @@
 					"version": "1.1.0",
 					"resolved": false,
 					"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"concat-map": {
 					"version": "0.0.1",
 					"resolved": false,
 					"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"console-control-strings": {
 					"version": "1.1.0",
 					"resolved": false,
 					"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"core-util-is": {
 					"version": "1.0.2",
@@ -3087,8 +3081,7 @@
 					"version": "2.0.3",
 					"resolved": false,
 					"integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"ini": {
 					"version": "1.3.5",
@@ -3102,7 +3095,6 @@
 					"resolved": false,
 					"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"number-is-nan": "^1.0.0"
 					}
@@ -3119,7 +3111,6 @@
 					"resolved": false,
 					"integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"brace-expansion": "^1.1.7"
 					}
@@ -3128,15 +3119,13 @@
 					"version": "0.0.8",
 					"resolved": false,
 					"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"minipass": {
 					"version": "2.2.4",
 					"resolved": false,
 					"integrity": "sha512-hzXIWWet/BzWhYs2b+u7dRHlruXhwdgvlTMDKC6Cb1U7ps6Ac6yQlR39xsbjWJE377YTCtKwIXIpJ5oP+j5y8g==",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"safe-buffer": "^5.1.1",
 						"yallist": "^3.0.0"
@@ -3157,7 +3146,6 @@
 					"resolved": false,
 					"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"minimist": "0.0.8"
 					}
@@ -3246,8 +3234,7 @@
 					"version": "1.0.1",
 					"resolved": false,
 					"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"object-assign": {
 					"version": "4.1.1",
@@ -3261,7 +3248,6 @@
 					"resolved": false,
 					"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"wrappy": "1"
 					}
@@ -3357,8 +3343,7 @@
 					"version": "5.1.1",
 					"resolved": false,
 					"integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"safer-buffer": {
 					"version": "2.1.2",
@@ -3400,7 +3385,6 @@
 					"resolved": false,
 					"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"code-point-at": "^1.0.0",
 						"is-fullwidth-code-point": "^1.0.0",
@@ -3422,7 +3406,6 @@
 					"resolved": false,
 					"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"ansi-regex": "^2.0.0"
 					}
@@ -3471,15 +3454,13 @@
 					"version": "1.0.2",
 					"resolved": false,
 					"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"yallist": {
 					"version": "3.0.2",
 					"resolved": false,
 					"integrity": "sha1-hFK0u36Dx8GI2AQcGoN8dz1ti7k=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				}
 			}
 		},
@@ -5053,7 +5034,6 @@
 					"resolved": false,
 					"integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"kind-of": "^3.0.2",
 						"longest": "^1.0.1",
@@ -5423,8 +5403,7 @@
 					"version": "1.1.6",
 					"resolved": false,
 					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"is-builtin-module": {
 					"version": "1.0.0",
@@ -5520,7 +5499,6 @@
 					"resolved": false,
 					"integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
 					"dev": true,
-					"optional": true,
 					"requires": {
 						"is-buffer": "^1.1.5"
 					}
@@ -5573,8 +5551,7 @@
 					"version": "1.0.1",
 					"resolved": false,
 					"integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"lru-cache": {
 					"version": "4.1.3",
@@ -5877,8 +5854,7 @@
 					"version": "1.6.1",
 					"resolved": false,
 					"integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
-					"dev": true,
-					"optional": true
+					"dev": true
 				},
 				"require-directory": {
 					"version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
 	"dependencies": {
 		"@ui5/logger": "^1.0.0",
 		"clone": "^2.1.0",
+		"dir-glob": "2.0.0",
 		"globby": "^7.1.1",
 		"graceful-fs": "^4.1.15",
 		"make-dir": "^1.1.0",


### PR DESCRIPTION
dir-glob is a transitive dependency of globby ("dir-glob": "^2.0.0").

Some of our tests ("GLOB root directory" and "GLOB (normalized) root
directory (=> fs root)") are failing when using dir-glob v2.2.0.

Therefore pinning it to v2.0.0 for the time being.

This came up in our preflight tests which ignore the package-lock.json:
npm install --no-shrinkwrap --no-package-lock

Note: This is unrelated to https://github.com/SAP/ui5-fs/pull/71
Tests were still failing after reverting that change.

Moreover, this is also reproducible on Git tag v0.2.0.