### PR TITLE
[INTERNAL] Tests: Replace deprecated Buffer constructor calls

### DIFF
--- a/test/lib/DuplexCollection.js
+++ b/test/lib/DuplexCollection.js
@@ -61,7 +61,7 @@ test("DuplexCollection: _byGlob", (t) => {
 
 	const resource = new Resource({
 		path: "my/path",
-		buffer: new Buffer("content")
+		buffer: Buffer.from("content")
 	});
 	const abstractReader = {
 		_byGlob: sinon.stub().returns(Promise.resolve([resource]))
@@ -115,7 +115,7 @@ test("DuplexCollection: _byGlobSource with default options and a reader finding 
 
 	const resource = new Resource({
 		path: "my/path",
-		buffer: new Buffer("content")
+		buffer: Buffer.from("content")
 	});
 	const abstractReader = {
 		byGlob: sinon.stub().returns(Promise.resolve([resource]))
@@ -144,7 +144,7 @@ test("DuplexCollection: _byPath with reader finding a resource", (t) => {
 
 	const resource = new Resource({
 		path: "path",
-		buffer: new Buffer("content")
+		buffer: Buffer.from("content")
 	});
 	const pushCollectionSpy = sinon.spy(resource, "pushCollection");
 	const abstractReader = {
@@ -205,7 +205,7 @@ test("DuplexCollection: _write successful", (t) => {
 
 	const resource = new Resource({
 		path: "my/path",
-		buffer: new Buffer("content")
+		buffer: Buffer.from("content")
 	});
 	const duplexCollection = new DuplexCollection({
 		name: "myCollection",

--- a/test/lib/ReaderCollection.js
+++ b/test/lib/ReaderCollection.js
@@ -42,7 +42,7 @@ test("ReaderCollection: _byGlob with finding a resource", (t) => {
 
 	const resource = new Resource({
 		path: "my/path",
-		buffer: new Buffer("content")
+		buffer: Buffer.from("content")
 	});
 	const abstractReader = {
 		_byGlob: sinon.stub().returns(Promise.resolve([resource]))
@@ -74,7 +74,7 @@ test("ReaderCollection: _byPath with reader finding a resource", (t) => {
 
 	const resource = new Resource({
 		path: "my/path",
-		buffer: new Buffer("content")
+		buffer: Buffer.from("content")
 	});
 	const pushCollectionSpy = sinon.spy(resource, "pushCollection");
 	const abstractReader = {

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -14,7 +14,7 @@ test("Resource: constructor with duplicated content parameter", (t) => {
 	const error = t.throws(() => {
 		new Resource({
 			path: "my/path",
-			buffer: new Buffer("Content"),
+			buffer: Buffer.from("Content"),
 			string: "Content"
 		});
 	}, Error);
@@ -41,7 +41,7 @@ test("Resource: getStream", async (t) => {
 
 	const resource = new Resource({
 		path: "my/path/to/resource",
-		buffer: new Buffer("Content")
+		buffer: Buffer.from("Content")
 	});
 
 	return new Promise(function(resolve, reject) {
@@ -109,7 +109,7 @@ test("Resource: clone resource with buffer", (t) => {
 
 	const resource = new Resource({
 		path: "my/path/to/resource",
-		buffer: new Buffer("Content")
+		buffer: Buffer.from("Content")
 	});
 
 	return resource.clone().then(function(clonedResource) {


### PR DESCRIPTION
The Buffer constructor used in some of our recently added tests
(https://github.com/SAP/ui5-fs/pull/56 is deprecated. One should
use Buffer.from(string) instead.

Details:
https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/