### PR TITLE
[DEPENDENCY] Yarn: Pin dir-glob dependency to v2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,5 +119,8 @@
 		"rimraf": "^2.6.3",
 		"sinon": "^7.2.3",
 		"tap-nyan": "^1.1.0"
+	},
+	"resolutions": {
+		"dir-glob": "2.0.0"
 	}
 }


### PR DESCRIPTION
Follow up of https://github.com/SAP/ui5-fs/pull/73
To pin a transitive dependency when using Yarn, "resolutions" need to be
used.