### PR TITLE
[WIP][PERF] FileSystem Adapter: Use native fs.copy when possible

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -39,7 +39,7 @@ class Resource {
 	 *					string or stream).
 	 *					In some cases this is the most memory-efficient way to supply resource content
 	 */
-	constructor({path, statInfo, buffer, string, createStream, stream, project}) {
+	constructor({path, statInfo, buffer, string, createStream, stream, source, project}) {
 		if (!path) {
 			throw new Error("Cannot create Resource: path parameter missing");
 		}
@@ -52,6 +52,7 @@ class Resource {
 		this._path = path;
 		this._name = this._getNameFromPath(path);
 		this._project = project; // Experimental, internal parameter
+		this._source = source; // Experimental, internal parameter
 		this._statInfo = statInfo || { // TODO
 			isFile: fnTrue,
 			isDirectory: fnFalse,
@@ -299,6 +300,10 @@ class Resource {
 		}
 
 		return tree;
+	}
+
+	getSource() {
+		return this._source || {};
 	}
 
 	/**

--- a/lib/adapters/FileSystem.js
+++ b/lib/adapters/FileSystem.js
@@ -58,6 +58,10 @@ class FileSystem extends AbstractAdapter {
 									project: this._project,
 									statInfo: stat,
 									path: this._virBaseDir,
+									source: {
+										adapter: "FileSystem",
+										fsPath: this._fsBasePath
+									},
 									createStream: () => {
 										return fs.createReadStream(this._fsBasePath);
 									}
@@ -81,6 +85,10 @@ class FileSystem extends AbstractAdapter {
 									project: this._project,
 									statInfo: stat,
 									path: virPath,
+									source: {
+										adapter: "FileSystem",
+										fsPath: fsPath
+									},
 									createStream: () => {
 										return fs.createReadStream(fsPath);
 									}
@@ -149,7 +157,10 @@ class FileSystem extends AbstractAdapter {
 						project: this._project,
 						statInfo: stat,
 						path: virPath,
-						fsPath
+						source: {
+							adapter: "FileSystem",
+							fsPath
+						}
 					};
 
 					if (!stat.isDirectory()) {
@@ -197,6 +208,21 @@ class FileSystem extends AbstractAdapter {
 
 		await makeDir(dirPath, {fs});
 		return new Promise((resolve, reject) => {
+			totalResources++;
+			const resourceSource = resource.getSource();
+			if (resource._createStream && resourceSource.adapter === "FileSystem" && resourceSource.fsPath) {
+				copiedResources++;
+				fs.copyFile(resourceSource.fsPath, fsPath, (err) => {
+					if (err) {
+						reject(err);
+					} else {
+						resolve();
+					}
+				});
+				return;
+			}
+
+
 			let contentStream;
 
 			if (drain || readOnly) {
@@ -245,5 +271,11 @@ class FileSystem extends AbstractAdapter {
 		});
 	}
 }
+
+let totalResources = 0;
+let copiedResources = 0;
+setInterval(() => {
+	console.log(`Copied ${copiedResources}/${totalResources} resources...`);
+}, 1000);
 
 module.exports = FileSystem;


### PR DESCRIPTION
Apparently did not seem to make much of a difference. Plus, this approach only applies to resources that have not been altered in the build process. Will try and do a proper comparison sometime in the future.