### PR TITLE
[BREAKING] Remove deprecated parameter useNamespaces

### DIFF
--- a/lib/resourceFactory.js
+++ b/lib/resourceFactory.js
@@ -47,8 +47,6 @@ const resourceFactory = {
 	 * @public
 	 * @param {Object} tree A (sub-)tree
 	 * @param {Object} [parameters] Parameters
-	 * @param {boolean} [parameters.useNamespaces=false] Use project namespaces as path prefixes
-	 *						DEPRECATED: Use parameter <code>getVirtualBasePathPrefix</code> instead.
 	 * @param {module:@ui5/fs.resourceFactory~getProjectExcludes} [parameters.getProjectExcludes]
 	 *						Callback to retrieve the exclude globs of a project
 	 * @param {module:@ui5/fs.resourceFactory~getVirtualBasePathPrefix} [parameters.getVirtualBasePathPrefix]
@@ -56,7 +54,7 @@ const resourceFactory = {
 	 * @returns {Object} Object containing <code>source</code> and <code>dependencies</code> resource readers
 	 */
 	createCollectionsForTree(tree, {
-		useNamespaces=false, getProjectExcludes, getVirtualBasePathPrefix, virtualReaders={}
+		getProjectExcludes, getVirtualBasePathPrefix, virtualReaders={}
 	} = {}) {
 		// TODO 2.0: virtualReaders is private API. The virtual reader of a project should be stored on the
 		//	project itself. This requires projects to become objects independent from the dependency tree.
@@ -66,18 +64,6 @@ const resourceFactory = {
 		const dependencyPathIndex = {};
 		const virtualReaderIndex = {};
 		const sourceResourceLocators = [];
-
-		if (useNamespaces) {
-			// TODO 2.0: Remove deprecated "useNamespaces" parameter
-			log.warn(`resourceFactory.createCollectionsForTree called with deprecated parameter "useNamespaces". ` +
-				`This parameter will be removed in @ui5/fs version 2.0. ` +
-				`Use parameter "getVirtualBasePathPrefix" instead`);
-		}
-		if (useNamespaces && getVirtualBasePathPrefix) {
-			throw new Error(
-				`resourceFactory.createCollectionsForTree called with parameters "useNamespace" and ` +
-				`"getVirtualBasePathPrefix". Please provide only one of the two.`);
-		}
 
 		function processDependencies(project) {
 			if (project.resources && project.resources.pathMappings) {
@@ -97,7 +83,6 @@ const resourceFactory = {
 						const fsAdapter = resourceFactory._createFsAdapterForVirtualBasePath({
 							project,
 							virBasePath,
-							useNamespace: useNamespaces,
 							getProjectExcludes,
 							getVirtualBasePathPrefix
 						});
@@ -131,7 +116,6 @@ const resourceFactory = {
 					const fsAdapter = resourceFactory._createFsAdapterForVirtualBasePath({
 						project: tree,
 						virBasePath,
-						useNamespace: useNamespaces,
 						getProjectExcludes,
 						getVirtualBasePathPrefix
 					});
@@ -165,7 +149,6 @@ const resourceFactory = {
 	 * @param {Object} parameters Parameters
 	 * @param {Project} parameters.project A project
 	 * @param {string} parameters.virBasePath Virtual base path to create the adapter for
-	 * @param {boolean} parameters.useNamespaces Use project namespace as path prefix
 	 * @param {module:@ui5/fs.resourceFactory~getProjectExcludes} [parameters.getProjectExcludes]
 	 *												Callback to retrieve the exclude glob of a project
 	 * @param {module:@ui5/fs.resourceFactory~getVirtualBasePathPrefix} [parameters.getVirtualBasePathPrefix]
@@ -173,7 +156,7 @@ const resourceFactory = {
 	 * @returns {Promise<string[]>} Promise resolving to list of normalized glob patterns
 	 */
 	_createFsAdapterForVirtualBasePath({
-		project, virBasePath, useNamespace, getProjectExcludes, getVirtualBasePathPrefix
+		project, virBasePath, getProjectExcludes, getVirtualBasePathPrefix
 	}) {
 		const fsPath = project.resources.pathMappings[virBasePath];
 		const fsBasePath = path.join(project.path, fsPath);
@@ -197,15 +180,6 @@ const resourceFactory = {
 					});
 					pathExcludes = Array.prototype.concat.apply([], normalizedPatterns);
 				}
-			}
-		} else if (useNamespace && project.metadata.namespace) { // Prefix resource paths with namespace
-			const namespacedBasePath = "/resources/" + project.metadata.namespace;
-			virBasePath = namespacedBasePath + virBasePath;
-			if (pathExcludes) {
-				const normalizedPatterns = pathExcludes.map((pattern) => {
-					return resourceFactory._prefixGlobPattern(pattern, namespacedBasePath);
-				});
-				pathExcludes = Array.prototype.concat.apply([], normalizedPatterns);
 			}
 		}
 

--- a/test/lib/resources.js
+++ b/test/lib/resources.js
@@ -93,8 +93,6 @@ test.serial("createCollectionsForTree", (t) => {
 		"First createAdapter call: Correct project supplied");
 	t.deepEqual(firstCall.virBasePath, "/",
 		"First createAdapter call: Correct virBasePath supplied");
-	t.deepEqual(firstCall.useNamespace, false,
-		"second createAdapter call: Correct useNamespace parameter supplied");
 	t.is(firstCall.getProjectExcludes, getProjectExcludesCallback,
 		"First createAdapter call: Correct getProjectExcludes parameter supplied");
 	t.is(firstCall.getVirtualBasePathPrefix, getVirtualBasePathPrefixCallback,
@@ -105,8 +103,6 @@ test.serial("createCollectionsForTree", (t) => {
 		"second createAdapter call: Correct project supplied");
 	t.deepEqual(secondCall.virBasePath, "/resources/",
 		"second createAdapter call: Correct virBasePath supplied");
-	t.deepEqual(secondCall.useNamespace, false,
-		"second createAdapter call: Correct useNamespace parameter supplied");
 	t.is(secondCall.getProjectExcludes, getProjectExcludesCallback,
 		"second createAdapter call: Correct getProjectExcludes parameter supplied");
 	t.is(secondCall.getVirtualBasePathPrefix, getVirtualBasePathPrefixCallback,
@@ -117,8 +113,6 @@ test.serial("createCollectionsForTree", (t) => {
 		"third createAdapter call: Correct project supplied");
 	t.deepEqual(thirdCall.virBasePath, "/test-resources/",
 		"third createAdapter call: Correct virBasePath supplied");
-	t.deepEqual(thirdCall.useNamespace, false,
-		"third createAdapter call: Correct useNamespace parameter supplied");
 	t.is(thirdCall.getProjectExcludes, getProjectExcludesCallback,
 		"third createAdapter call: Correct getProjectExcludes parameter supplied");
 	t.is(thirdCall.getVirtualBasePathPrefix, getVirtualBasePathPrefixCallback,
@@ -129,8 +123,6 @@ test.serial("createCollectionsForTree", (t) => {
 		"fourth createAdapter call: Correct project supplied");
 	t.deepEqual(fourthCall.virBasePath, "/resources/",
 		"fourth createAdapter call: Correct virBasePath supplied");
-	t.deepEqual(fourthCall.useNamespace, false,
-		"fourth createAdapter call: Correct useNamespace parameter supplied");
 	t.is(fourthCall.getProjectExcludes, getProjectExcludesCallback,
 		"fourth createAdapter call: Correct getProjectExcludes parameter supplied");
 	t.is(fourthCall.getVirtualBasePathPrefix, getVirtualBasePathPrefixCallback,
@@ -141,8 +133,6 @@ test.serial("createCollectionsForTree", (t) => {
 		"fifth createAdapter call: Correct project supplied");
 	t.deepEqual(fifthCall.virBasePath, "/test-resources/",
 		"fifth createAdapter call: Correct virBasePath supplied");
-	t.deepEqual(fifthCall.useNamespace, false,
-		"fifth createAdapter call: Correct useNamespace parameter supplied");
 	t.is(fifthCall.getProjectExcludes, getProjectExcludesCallback,
 		"fifth createAdapter call: Correct getProjectExcludes parameter supplied");
 	t.is(fifthCall.getVirtualBasePathPrefix, getVirtualBasePathPrefixCallback,
@@ -153,8 +143,6 @@ test.serial("createCollectionsForTree", (t) => {
 		"sixth createAdapter call: Correct project supplied");
 	t.deepEqual(sixthCall.virBasePath, "/resources/",
 		"sixth createAdapter call: Correct virBasePath supplied");
-	t.deepEqual(sixthCall.useNamespace, false,
-		"sixth createAdapter call: Correct useNamespace parameter supplied");
 	t.is(sixthCall.getProjectExcludes, getProjectExcludesCallback,
 		"sixth createAdapter call: Correct getProjectExcludes parameter supplied");
 	t.is(sixthCall.getVirtualBasePathPrefix, getVirtualBasePathPrefixCallback,
@@ -165,8 +153,6 @@ test.serial("createCollectionsForTree", (t) => {
 		"seventh createAdapter call: Correct project supplied");
 	t.deepEqual(seventhCall.virBasePath, "/test-resources/",
 		"seventh createAdapter call: Correct virBasePath supplied");
-	t.deepEqual(seventhCall.useNamespace, false,
-		"seventh createAdapter call: Correct useNamespace parameter supplied");
 	t.is(seventhCall.getProjectExcludes, getProjectExcludesCallback,
 		"seventh createAdapter call: Correct getProjectExcludes parameter supplied");
 	t.is(seventhCall.getVirtualBasePathPrefix, getVirtualBasePathPrefixCallback,
@@ -177,8 +163,6 @@ test.serial("createCollectionsForTree", (t) => {
 		"eight createAdapter call: Correct project supplied");
 	t.deepEqual(eightCall.virBasePath, "/resources/",
 		"eight createAdapter call: Correct virBasePath supplied");
-	t.deepEqual(eightCall.useNamespace, false,
-		"eight createAdapter call: Correct useNamespace parameter supplied");
 	t.is(eightCall.getProjectExcludes, getProjectExcludesCallback,
 		"eight createAdapter call: Correct getProjectExcludes parameter supplied");
 	t.is(eightCall.getVirtualBasePathPrefix, getVirtualBasePathPrefixCallback,
@@ -189,8 +173,6 @@ test.serial("createCollectionsForTree", (t) => {
 		"ninth createAdapter call: Correct project supplied");
 	t.deepEqual(ninthCall.virBasePath, "/test-resources/",
 		"ninth createAdapter call: Correct virBasePath supplied");
-	t.deepEqual(ninthCall.useNamespace, false,
-		"ninth createAdapter call: Correct useNamespace parameter supplied");
 	t.is(ninthCall.getProjectExcludes, getProjectExcludesCallback,
 		"ninth createAdapter call: Correct getProjectExcludes parameter supplied");
 	t.is(ninthCall.getVirtualBasePathPrefix, getVirtualBasePathPrefixCallback,


### PR DESCRIPTION
BREAKING CHANGE:
Remove deprecated parameter "useNamespaces" from
method "resourceFactory.createCollectionsForTree".
Use parameter "getVirtualBasePathPrefix" instead.
