### PR TITLE
[INTERNAL] Adapt tests to new project._isRoot flag

### DIFF
--- a/test/lib/resources.js
+++ b/test/lib/resources.js
@@ -449,6 +449,7 @@ const applicationBTree = {
 	],
 	"builder": {},
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {
@@ -542,6 +543,7 @@ const applicationBTreeWithExcludes = {
 		]
 	},
 	"_level": 0,
+	"_isRoot": true,
 	"specVersion": "0.1",
 	"type": "application",
 	"metadata": {


### PR DESCRIPTION
Flag was added with https://github.com/SAP/ui5-project/pull/287
Tests are not failing. This is just for consistency reasons and to
prevent future issues.