### PR TITLE
[FIX] Resource: getStream for empty string

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -73,7 +73,7 @@ class Resource {
 		this._createStream = createStream || null;
 		this._stream = stream || null;
 		this._buffer = buffer || null;
-		if (typeof string === "string") {
+		if (typeof string === "string" || string instanceof String) {
 			this._buffer = Buffer.from(string, "utf8");
 		}
 

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -73,7 +73,7 @@ class Resource {
 		this._createStream = createStream || null;
 		this._stream = stream || null;
 		this._buffer = buffer || null;
-		if (string) {
+		if (typeof string === "string") {
 			this._buffer = Buffer.from(string, "utf8");
 		}
 

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -185,12 +185,6 @@ test("Resource: clone resource with stream", (t) => {
 	});
 });
 
-test("getStream for empty file: correctly retrieved", async (t) => {
-	const resource = createBasicResource("empty.js");
-	const result = await readStream(resource.getStream());
-	t.is(result, "", "empty content");
-});
-
 test("getStream with createStream callback content: Subsequent content requests should throw error due " +
 		"to drained content", async (t) => {
 	const resource = createBasicResource();

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -18,14 +18,23 @@ function createBasicResource(fileName = "index.html") {
 	return resource;
 }
 
+/**
+ * Reads a readable stream and resolves with its content
+ *
+ * @param {stream.Readable} readableStream readable stream
+ * @returns {Promise<string>} resolves with the read string
+ */
 const readStream = (readableStream) => {
-	return new Promise((resolve) => {
+	return new Promise((resolve, reject) => {
 		let streamedResult = "";
 		readableStream.on("data", (chunk) => {
 			streamedResult += chunk;
 		});
 		readableStream.on("end", () => {
 			resolve(streamedResult);
+		});
+		readableStream.on("error", (err) => {
+			reject(err);
 		});
 	});
 };
@@ -178,8 +187,8 @@ test("Resource: clone resource with stream", (t) => {
 
 test("getStream for empty file: correctly retrieved", async (t) => {
 	const resource = createBasicResource("empty.js");
-	const string = await readStream(resource.getStream());
-	t.is(string, "", "empty content");
+	const result = await readStream(resource.getStream());
+	t.is(result, "", "empty content");
 });
 
 test("getStream with createStream callback content: Subsequent content requests should throw error due " +

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -4,10 +4,10 @@ const fs = require("fs");
 const path = require("path");
 const Resource = require("../../lib/Resource");
 
-function createBasicResource(fileName = "index.html") {
-	const fsPath = path.join("test", "fixtures", "application.a", "webapp", fileName);
+function createBasicResource() {
+	const fsPath = path.join("test", "fixtures", "application.a", "webapp", "index.html");
 	const resource = new Resource({
-		path: "/app/" + fileName,
+		path: "/app/index.html",
 		createStream: function() {
 			return fs.createReadStream(fsPath);
 		},

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -101,6 +101,20 @@ test("Resource: getStream for empty string", async (t) => {
 	});
 });
 
+test("Resource: getStream for empty string instance", async (t) => {
+	t.plan(1);
+
+	const resource = new Resource({
+		path: "my/path/to/resource",
+		// eslint-disable-next-line no-new-wrappers
+		string: new String("")
+	});
+
+	return readStream(resource.getStream()).then((result) => {
+		t.is(result, "", "Stream has been read correctly for empty string");
+	});
+});
+
 test("Resource: getStream throwing an error", (t) => {
 	const resource = new Resource({
 		path: "my/path/to/resource"

--- a/test/lib/adapters/FileSystem_read.js
+++ b/test/lib/adapters/FileSystem_read.js
@@ -94,7 +94,7 @@ test("glob resources from application.a with directory exclude", async (t) => {
 	});
 
 	await readerWriter.byGlob("/!(pony,unicorn)/**").then(function(resources) {
-		t.deepEqual(resources.length, 3, "Found exactly two resource");
+		t.deepEqual(resources.length, 3, "Found exactly three resource");
 	});
 });
 

--- a/test/lib/adapters/FileSystem_read.js
+++ b/test/lib/adapters/FileSystem_read.js
@@ -94,7 +94,7 @@ test("glob resources from application.a with directory exclude", async (t) => {
 	});
 
 	await readerWriter.byGlob("/!(pony,unicorn)/**").then(function(resources) {
-		t.deepEqual(resources.length, 2, "Found exactly two resource");
+		t.deepEqual(resources.length, 3, "Found exactly two resource");
 	});
 });
 

--- a/test/lib/adapters/FileSystem_read.js
+++ b/test/lib/adapters/FileSystem_read.js
@@ -94,7 +94,7 @@ test("glob resources from application.a with directory exclude", async (t) => {
 	});
 
 	await readerWriter.byGlob("/!(pony,unicorn)/**").then(function(resources) {
-		t.deepEqual(resources.length, 3, "Found exactly three resource");
+		t.deepEqual(resources.length, 2, "Found exactly two resource");
 	});
 });
 


### PR DESCRIPTION
If a resource does not have any content (empty string), the stream still can be retrieved.
Before the error `Resource ${this._path} has no content`
was thrown for the empty string.


Add additional test "getStream for empty file: correctly retrieved" which uses a buffer for an empty file for completeness.