### PR TITLE
[FIX] TypeScript type definition support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,43 +2,73 @@
  * @module @ui5/fs
  * @public
  */
-const modules = {
+module.exports = {
 	/**
 	 * @public
 	 * @alias module:@ui5/fs.adapters
 	 * @namespace
 	 */
 	adapters: {
+		/**
+		 * @type {typeof import('./lib/adapters/AbstractAdapter')}
+		 */
 		AbstractAdapter: "./lib/adapters/AbstractAdapter",
+		/**
+		 * @type {typeof import('./lib/adapters/FileSystem')}
+		 */
 		FileSystem: "./lib/adapters/FileSystem",
+		/**
+		 * @type {typeof import('./lib/adapters/Memory')}
+		 */
 		Memory: "./lib/adapters/Memory"
 	},
+	/**
+	 * @type {typeof import('./lib/AbstractReader')}
+	 */
 	AbstractReader: "./lib/AbstractReader",
+	/**
+	 * @type {typeof import('./lib/AbstractReaderWriter')}
+	 */
 	AbstractReaderWriter: "./lib/AbstractReaderWriter",
+	/**
+	 * @type {typeof import('./lib/DuplexCollection')}
+	 */
 	DuplexCollection: "./lib/DuplexCollection",
+	/**
+	 * @type {import('./lib/fsInterface')}
+	 */
 	fsInterface: "./lib/fsInterface",
+	/**
+	 * @type {typeof import('./lib/ReaderCollection')}
+	 */
 	ReaderCollection: "./lib/ReaderCollection",
+	/**
+	 * @type {typeof import('./lib/ReaderCollectionPrioritized')}
+	 */
 	ReaderCollectionPrioritized: "./lib/ReaderCollectionPrioritized",
+	/**
+	 * @type {typeof import('./lib/Resource')}
+	 */
 	Resource: "./lib/Resource",
+	/**
+	 * @type {import('./lib/resourceFactory')}
+	 */
 	resourceFactory: "./lib/resourceFactory"
 };
 
-const hasOwnProperty = Object.prototype.hasOwnProperty;
 function exportModules(exportRoot, modulePaths) {
-	for (const moduleName in modulePaths) {
-		if (hasOwnProperty.call(modulePaths, moduleName)) {
-			if (typeof modulePaths[moduleName] === "object") {
-				exportRoot[moduleName] = {};
-				exportModules(exportRoot[moduleName], modulePaths[moduleName]);
-			} else {
-				Object.defineProperty(exportRoot, moduleName, {
-					get() {
-						return require(modulePaths[moduleName]);
-					}
-				});
-			}
+	for (const moduleName of Object.keys(modulePaths)) {
+		if (typeof modulePaths[moduleName] === "object") {
+			exportRoot[moduleName] = {};
+			exportModules(exportRoot[moduleName], modulePaths[moduleName]);
+		} else {
+			Object.defineProperty(exportRoot, moduleName, {
+				get() {
+					return require(modulePaths[moduleName]);
+				}
+			});
 		}
 	}
 }
 
-exportModules(module.exports, modules);
+exportModules(module.exports, JSON.parse(JSON.stringify(module.exports)));

--- a/jsdoc-plugin-ignore-ts-import/index.js
+++ b/jsdoc-plugin-ignore-ts-import/index.js
@@ -1,0 +1,13 @@
+/*
+ * Removes JSDoc comments with TypeScript import() declarations
+ */
+
+const IMPORT_PATTERN = /{(?:typeof )?import\(["'][^"']*["']\)[ .|}><,)=#\n]/;
+
+exports.handlers = {
+	jsdocCommentFound: function(e) {
+		if (IMPORT_PATTERN.test(e.comment)) {
+			e.comment = "";
+		}
+	}
+};

--- a/jsdoc-plugin.js
+++ b/jsdoc-plugin.js
@@ -1,5 +1,5 @@
 /*
- * Removes JSDoc comments with TypeScript import() declarations
+ * Removes JSDoc comments with TypeScript import() declarations (used in index.js)
  */
 
 const IMPORT_PATTERN = /{(?:typeof )?import\(["'][^"']*["']\)[ .|}><,)=#\n]/;

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -7,7 +7,9 @@
         "includePattern": ".+\\.js$",
         "excludePattern": "(node_modules(\\\\|/))"
     },
-    "plugins": [],
+    "plugins": [
+		"./jsdoc-plugin-ignore-ts-import"
+	],
     "opts": {
         "template": "node_modules/docdash/",
         "encoding": "utf8",
@@ -56,5 +58,5 @@
                 "id": "github_link"
             }
         }
-    }
+	}
 }

--- a/jsdoc.json
+++ b/jsdoc.json
@@ -1,62 +1,62 @@
 {
-    "tags": {
-        "allowUnknownTags": false
-    },
-    "source": {
-        "include": ["README.md", "index.js"],
-        "includePattern": ".+\\.js$",
-        "excludePattern": "(node_modules(\\\\|/))"
-    },
-    "plugins": [
-		"./jsdoc-plugin-ignore-ts-import"
+	"tags": {
+		"allowUnknownTags": false
+	},
+	"source": {
+		"include": ["README.md", "index.js"],
+		"includePattern": ".+\\.js$",
+		"excludePattern": "(node_modules(\\\\|/))"
+	},
+	"plugins": [
+		"./jsdoc-plugin"
 	],
-    "opts": {
-        "template": "node_modules/docdash/",
-        "encoding": "utf8",
-        "destination": "jsdocs/",
-        "recurse": true,
-        "verbose": true,
-        "access": "public"
-    },
-    "templates": {
-        "cleverLinks": false,
-        "monospaceLinks": false,
-        "default": {
-            "useLongnameInNav": true
-        }
-    },
-    "openGraph": {
-        "title": "UI5 Tooling - API Reference",
-        "type": "website",
-        "image": "https://sap.github.io/ui5-tooling/docs/images/UI5_logo_wide.png",
-        "site_name": "UI5 Tooling - API Reference",
-        "url": "https://sap.github.io/ui5-tooling/"
-    },
-    "docdash": {
-        "sectionOrder": [
-            "Modules",
-            "Namespaces",
-            "Classes",
-            "Externals",
-            "Events",
-            "Mixins",
-            "Tutorials",
-            "Interfaces"
-        ],
-        "meta": {
-            "title": "UI5 Tooling - API Reference - UI5 FS",
-            "description": "UI5 Tooling - API Reference - UI5 FS",
-            "keyword": "openui5 sapui5 ui5 build development tool api reference"
-        },
-        "search": true,
-        "wrap": true,
-        "menu": {
-            "GitHub": {
-                "href": "https://github.com/SAP/ui5-fs",
-                "target": "_blank",
-                "class": "menu-item",
-                "id": "github_link"
-            }
-        }
+	"opts": {
+		"template": "node_modules/docdash/",
+		"encoding": "utf8",
+		"destination": "jsdocs/",
+		"recurse": true,
+		"verbose": true,
+		"access": "public"
+	},
+	"templates": {
+		"cleverLinks": false,
+		"monospaceLinks": false,
+		"default": {
+			"useLongnameInNav": true
+		}
+	},
+	"openGraph": {
+		"title": "UI5 Tooling - API Reference",
+		"type": "website",
+		"image": "https://sap.github.io/ui5-tooling/docs/images/UI5_logo_wide.png",
+		"site_name": "UI5 Tooling - API Reference",
+		"url": "https://sap.github.io/ui5-tooling/"
+	},
+	"docdash": {
+		"sectionOrder": [
+			"Modules",
+			"Namespaces",
+			"Classes",
+			"Externals",
+			"Events",
+			"Mixins",
+			"Tutorials",
+			"Interfaces"
+		],
+		"meta": {
+			"title": "UI5 Tooling - API Reference - UI5 FS",
+			"description": "UI5 Tooling - API Reference - UI5 FS",
+			"keyword": "openui5 sapui5 ui5 build development tool api reference"
+		},
+		"search": true,
+		"wrap": true,
+		"menu": {
+			"GitHub": {
+				"href": "https://github.com/SAP/ui5-fs",
+				"target": "_blank",
+				"class": "menu-item",
+				"id": "github_link"
+			}
+		}
 	}
 }


### PR DESCRIPTION
Lazy-loading breaks the automatic type definition detection from
TypeScript. Therefore we need to manually declare the exported types.