### PR TITLE
Revert "[FIX] adapters/Memory: Return cloned resources"

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -282,8 +282,7 @@ class Resource {
 	clone() {
 		const options = {
 			path: this._path,
-			statInfo: clone(this._statInfo),
-			project: this._project
+			statInfo: clone(this._statInfo)
 		};
 
 		const addContentOption = () => {

--- a/lib/adapters/Memory.js
+++ b/lib/adapters/Memory.js
@@ -26,24 +26,6 @@ class Memory extends AbstractAdapter {
 	}
 
 	/**
-	 * Matches and returns resources from a given map (either _virFiles or _virDirs).
-	 *
-	 * @private
-	 * @param {string[]} patterns
-	 * @param {object} resourceMap
-	 * @returns {Promise<module:@ui5/fs.Resource[]>}
-	 */
-	async _matchPatterns(patterns, resourceMap) {
-		const resourcePaths = Object.keys(resourceMap);
-		const matchedPaths = micromatch(resourcePaths, patterns, {
-			dot: true
-		});
-		return Promise.all(matchedPaths.map((virPath) => {
-			return resourceMap[virPath] && resourceMap[virPath].clone();
-		}));
-	}
-
-	/**
 	 * Locate resources by glob.
 	 *
 	 * @private
@@ -68,11 +50,22 @@ class Memory extends AbstractAdapter {
 			];
 		}
 
-		let matchedResources = await this._matchPatterns(patterns, this._virFiles);
+		const filePaths = Object.keys(this._virFiles);
+		const matchedFilePaths = micromatch(filePaths, patterns, {
+			dot: true
+		});
+		let matchedResources = matchedFilePaths.map((virPath) => {
+			return this._virFiles[virPath];
+		});
 
 		if (!options.nodir) {
-			const matchedDirs = await this._matchPatterns(patterns, this._virDirs);
-			matchedResources = matchedResources.concat(matchedDirs);
+			const dirPaths = Object.keys(this._virDirs);
+			const matchedDirs = micromatch(dirPaths, patterns, {
+				dot: true
+			});
+			matchedResources = matchedResources.concat(matchedDirs.map((virPath) => {
+				return this._virDirs[virPath];
+			}));
 		}
 
 		return matchedResources;
@@ -87,25 +80,28 @@ class Memory extends AbstractAdapter {
 	 * @param {module:@ui5/fs.tracing.Trace} trace Trace instance
 	 * @returns {Promise<module:@ui5/fs.Resource>} Promise resolving to a single resource
 	 */
-	async _byPath(virPath, options, trace) {
+	_byPath(virPath, options, trace) {
 		if (this.isPathExcluded(virPath)) {
-			return null;
+			return Promise.resolve(null);
 		}
-		if (!virPath.startsWith(this._virBasePath) && virPath !== this._virBaseDir) {
-			// Neither starts with basePath, nor equals baseDirectory
-			return null;
-		}
+		return new Promise((resolve, reject) => {
+			if (!virPath.startsWith(this._virBasePath) && virPath !== this._virBaseDir) {
+				// Neither starts with basePath, nor equals baseDirectory
+				resolve(null);
+				return;
+			}
 
-		const relPath = virPath.substr(this._virBasePath.length);
-		trace.pathCall();
+			const relPath = virPath.substr(this._virBasePath.length);
+			trace.pathCall();
 
-		const resource = this._virFiles[relPath];
+			const resource = this._virFiles[relPath];
 
-		if (!resource || (options.nodir && resource.getStatInfo().isDirectory())) {
-			return null;
-		} else {
-			return await resource.clone();
-		}
+			if (!resource || (options.nodir && resource.getStatInfo().isDirectory())) {
+				resolve(null);
+			} else {
+				resolve(resource);
+			}
+		});
 	}
 
 	/**

--- a/test/lib/adapters/Memory_read.js
+++ b/test/lib/adapters/Memory_read.js
@@ -1,6 +1,5 @@
 const test = require("ava");
 const {resourceFactory} = require("../../../");
-const MemoryAdapter = require("../../../lib/adapters/Memory");
 
 async function fillFromFs(readerWriter, {fsBasePath = "./test/fixtures/glob", virBasePath = "/app/"} = {}) {
 	const fsReader = resourceFactory.createAdapter({
@@ -606,60 +605,4 @@ test("static excludes: glob with negated directory exclude, not excluding resour
 	const resources = await srcReader.byGlob("/**/*", {nodir: false});
 
 	t.deepEqual(resources.length, 4, "Found two resources and two directories");
-});
-
-test("byPath returns new resource", async (t) => {
-	const originalResource = resourceFactory.createResource({
-		path: "/app/index.html",
-		string: "test"
-	});
-
-	const memoryAdapter = new MemoryAdapter({virBasePath: "/"});
-
-	await memoryAdapter.write(originalResource);
-
-	const returnedResource = await memoryAdapter.byPath("/app/index.html");
-
-	t.deepEqual(returnedResource, originalResource,
-		"Returned resource should be deep equal to original resource");
-	t.not(returnedResource, originalResource,
-		"Returned resource should not have same reference as original resource");
-
-	const anotherReturnedResource = await memoryAdapter.byPath("/app/index.html");
-
-	t.deepEqual(anotherReturnedResource, originalResource,
-		"Returned resource should be deep equal to original resource");
-	t.not(anotherReturnedResource, originalResource,
-		"Returned resource should not have same reference as original resource");
-
-	t.not(returnedResource, anotherReturnedResource,
-		"Both returned resources should not have same reference");
-});
-
-test("byGlob returns new resources", async (t) => {
-	const originalResource = resourceFactory.createResource({
-		path: "/app/index.html",
-		string: "test"
-	});
-
-	const memoryAdapter = new MemoryAdapter({virBasePath: "/"});
-
-	await memoryAdapter.write(originalResource);
-
-	const [returnedResource] = await memoryAdapter.byGlob("/**");
-
-	t.deepEqual(returnedResource, originalResource,
-		"Returned resource should be deep equal to the original resource");
-	t.not(returnedResource, originalResource,
-		"Returned resource should not have same reference as the original resource");
-
-	const [anotherReturnedResource] = await memoryAdapter.byGlob("/**");
-
-	t.deepEqual(anotherReturnedResource, originalResource,
-		"Another returned resource should be deep equal to the original resource");
-	t.not(anotherReturnedResource, originalResource,
-		"Another returned resource should not have same reference as the original resource");
-
-	t.not(returnedResource, anotherReturnedResource,
-		"Both returned resources should not have same reference");
 });


### PR DESCRIPTION
Reverts https://github.com/SAP/ui5-fs/pull/235 as discussed in todays planning.

We don't want to release https://github.com/SAP/ui5-fs/pull/235 without https://github.com/SAP/ui5-fs/pull/259. However, https://github.com/SAP/ui5-fs/pull/259 breaks tests in ui5-builder and might be incompatible in general. Also it's currently not critical for us.