### PR TITLE
[FIX] ResourceTagCollection: Do not validate class of resource

### DIFF
--- a/lib/ResourceTagCollection.js
+++ b/lib/ResourceTagCollection.js
@@ -1,8 +1,6 @@
 const tagNamespaceRegExp = new RegExp("^[a-z][a-z0-9]*$"); // part before the colon
 const tagNameRegExp = new RegExp("^[A-Z][A-Za-z0-9]+$"); // part after the colon
 
-const Resource = require("./Resource");
-
 class ResourceTagCollection {
 	constructor({allowedTags}) {
 		if (!allowedTags || !allowedTags.length) {
@@ -47,8 +45,9 @@ class ResourceTagCollection {
 	}
 
 	_validateResource(resource) {
-		if (!(resource instanceof Resource)) {
-			throw new Error(`Invalid Resource: Must be instance of @ui5/fs.Resource`);
+		const path = resource.getPath();
+		if (!path) {
+			throw new Error(`Invalid Resource: Resource path must not be empty`);
 		}
 	}
 

--- a/test/lib/ResourceTagCollection.js
+++ b/test/lib/ResourceTagCollection.js
@@ -278,3 +278,17 @@ test("_validateValue: Invalid value null", (t) => {
 		message: "Invalid Tag Value: Must be of type string, number or boolean but is object"
 	});
 });
+
+test("_validateResource: Empty path", (t) => {
+	const tagCollection = new ResourceTagCollection({
+		allowedTags: ["abc:MyTag"]
+	});
+	t.throws(() => {
+		tagCollection._validateResource({
+			getPath: () => ""
+		});
+	}, {
+		instanceOf: Error,
+		message: "Invalid Resource: Resource path must not be empty"
+	});
+});


### PR DESCRIPTION
This can lead to issues where a custom task creates resources using a
different version of @ui5/fs. These reosurces will fail the instanceof
check that was implemented here.

Instead of checking for the class, we now validate that the resource has
a path. The path is currently the only relevant attribute for
ResourceTagCollection and mandatory for Resources.

Resolves https://github.com/SAP/ui5-fs/issues/269