### PR TITLE
[INTERNAL] Replace globby with fast-glob

### DIFF
--- a/lib/adapters/FileSystem.js
+++ b/lib/adapters/FileSystem.js
@@ -4,7 +4,7 @@ const {promisify} = require("util");
 const fs = require("graceful-fs");
 const copyFile = promisify(fs.copyFile);
 const chmod = promisify(fs.chmod);
-const globby = require("globby");
+const fastGlob = require("fast-glob");
 const makeDir = require("make-dir");
 const {PassThrough} = require("stream");
 const AbstractAdapter = require("./AbstractAdapter");
@@ -84,7 +84,7 @@ class FileSystem extends AbstractAdapter {
 			return pattern !== "";
 		});
 		if (globbyPatterns.length > 0) {
-			const matches = await globby(globbyPatterns, opt);
+			const matches = await fastGlob(globbyPatterns, opt);
 			for (let i = matches.length - 1; i >= 0; i--) {
 				promises.push(new Promise((resolve, reject) => {
 					const fsPath = path.join(this._fsBasePath, matches[i]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
 				"@ui5/logger": "^3.0.1-alpha.1",
 				"clone": "^2.1.0",
 				"escape-string-regexp": "^4.0.0",
-				"globby": "^11.1.0",
+				"fast-glob": "^3.2.11",
 				"graceful-fs": "^4.2.9",
 				"make-dir": "^3.1.0",
 				"micromatch": "^4.0.4",
@@ -1071,6 +1071,7 @@
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -2370,6 +2371,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
 			"dependencies": {
 				"path-type": "^4.0.0"
 			},
@@ -3208,6 +3210,7 @@
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dev": true,
 			"dependencies": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
@@ -3373,6 +3376,7 @@
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
 			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"dev": true,
 			"engines": {
 				"node": ">= 4"
 			}
@@ -5162,6 +5166,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -5965,6 +5970,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -7891,7 +7897,8 @@
 		"array-union": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+			"dev": true
 		},
 		"arrgv": {
 			"version": "1.0.2",
@@ -8873,6 +8880,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+			"dev": true,
 			"requires": {
 				"path-type": "^4.0.0"
 			}
@@ -9509,6 +9517,7 @@
 			"version": "11.1.0",
 			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+			"dev": true,
 			"requires": {
 				"array-union": "^2.1.0",
 				"dir-glob": "^3.0.1",
@@ -9628,7 +9637,8 @@
 		"ignore": {
 			"version": "5.2.0",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
-			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
+			"integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+			"dev": true
 		},
 		"ignore-by-default": {
 			"version": "2.1.0",
@@ -10987,7 +10997,8 @@
 		"path-type": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+			"dev": true
 		},
 		"pathval": {
 			"version": "1.1.1",
@@ -11566,7 +11577,8 @@
 		"slash": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+			"dev": true
 		},
 		"slice-ansi": {
 			"version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
 		"@ui5/logger": "^3.0.1-alpha.1",
 		"clone": "^2.1.0",
 		"escape-string-regexp": "^4.0.0",
-		"globby": "^11.1.0",
+		"fast-glob": "^3.2.11",
 		"graceful-fs": "^4.2.9",
 		"make-dir": "^3.1.0",
 		"micromatch": "^4.0.4",


### PR DESCRIPTION
Replace `globby` with `fast-glob`.

**Background Information:**
Since `globby` version 12 only usage of esm is possible. CommonJS imports via `require` are not longer possible. `globby` uses `fast-glob` under the hood. By changing to `fast-glob` we can still use latest fixes of `fast-glob`.