### PR TITLE
[INTERNAL] use eslint-plugin-ava and cleanup test-suite

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,9 +3,10 @@ module.exports = {
 		"node": true,
 		"es2021": true
 	},
-	"extends": ["eslint:recommended", "google"],
+	"extends": ["eslint:recommended", "plugin:ava/recommended", "google"],
 	"plugins": [
-		"jsdoc"
+		"jsdoc",
+		"ava"
 	],
 	"rules": {
 		"indent": [
@@ -64,7 +65,10 @@ module.exports = {
 		"jsdoc/require-returns": 0,
 		"jsdoc/require-returns-description": 0,
 		"jsdoc/require-returns-type": 2,
-		"jsdoc/valid-types": 0
+		"jsdoc/valid-types": 0,
+		// ava/assertion-arguments reports concatenated strings in a assertion message as an issue
+		// See: https://github.com/avajs/eslint-plugin-ava/issues/332
+		"ava/assertion-arguments": 0
 	},
 	"settings": {
 		"jsdoc": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
 				"docdash": "^1.2.0",
 				"eslint": "^8.7.0",
 				"eslint-config-google": "^0.14.0",
+				"eslint-plugin-ava": "^13.2.0",
 				"eslint-plugin-jsdoc": "^37.6.3",
 				"jsdoc": "^3.6.7",
 				"mock-require": "^3.0.3",
@@ -2490,6 +2491,18 @@
 				"once": "^1.4.0"
 			}
 		},
+		"node_modules/enhance-visitors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+			"integrity": "sha512-+29eJLiUixTEDRaZ35Vu8jP3gPLNcQQkQkOQjLp2X+6cZGGPDD/uasbFzvLsJKnGZnvmyZ0srxudwOtskHeIDA==",
+			"dev": true,
+			"dependencies": {
+				"lodash": "^4.13.1"
+			},
+			"engines": {
+				"node": ">=4.0.0"
+			}
+		},
 		"node_modules/entities": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -2620,6 +2633,110 @@
 			},
 			"peerDependencies": {
 				"eslint": ">=5.16.0"
+			}
+		},
+		"node_modules/eslint-plugin-ava": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"dev": true,
+			"dependencies": {
+				"enhance-visitors": "^1.0.0",
+				"eslint-utils": "^3.0.0",
+				"espree": "^9.0.0",
+				"espurify": "^2.1.1",
+				"import-modules": "^2.1.0",
+				"micro-spelling-correcter": "^1.1.1",
+				"pkg-dir": "^5.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12.22 <13 || >=14.17 <15 || >=16.4"
+			},
+			"peerDependencies": {
+				"eslint": ">=7.22.0"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/find-up": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+			"dev": true,
+			"dependencies": {
+				"locate-path": "^6.0.0",
+				"path-exists": "^4.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/locate-path": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+			"dev": true,
+			"dependencies": {
+				"p-locate": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/p-limit": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+			"dev": true,
+			"dependencies": {
+				"yocto-queue": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/p-locate": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+			"dev": true,
+			"dependencies": {
+				"p-limit": "^3.0.2"
+			},
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/pkg-dir": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+			"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+			"dev": true,
+			"dependencies": {
+				"find-up": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=10"
+			}
+		},
+		"node_modules/eslint-plugin-ava/node_modules/resolve-from": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+			"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+			"dev": true,
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/eslint-plugin-jsdoc": {
@@ -2776,6 +2893,12 @@
 			"engines": {
 				"node": ">=4"
 			}
+		},
+		"node_modules/espurify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
+			"integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
+			"dev": true
 		},
 		"node_modules/esquery": {
 			"version": "1.4.0",
@@ -3428,6 +3551,18 @@
 			"bin": {
 				"import-local-fixture": "fixtures/cli.js"
 			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/import-modules": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+			"integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+			"dev": true,
 			"engines": {
 				"node": ">=8"
 			},
@@ -4418,6 +4553,12 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/micro-spelling-correcter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+			"integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
+			"dev": true
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.5",
@@ -7069,6 +7210,18 @@
 			"engines": {
 				"node": ">=10"
 			}
+		},
+		"node_modules/yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true,
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		}
 	},
 	"dependencies": {
@@ -8974,6 +9127,15 @@
 				"once": "^1.4.0"
 			}
 		},
+		"enhance-visitors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/enhance-visitors/-/enhance-visitors-1.0.0.tgz",
+			"integrity": "sha512-+29eJLiUixTEDRaZ35Vu8jP3gPLNcQQkQkOQjLp2X+6cZGGPDD/uasbFzvLsJKnGZnvmyZ0srxudwOtskHeIDA==",
+			"dev": true,
+			"requires": {
+				"lodash": "^4.13.1"
+			}
+		},
 		"entities": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/entities/-/entities-2.1.0.tgz",
@@ -9115,6 +9277,76 @@
 			"dev": true,
 			"requires": {}
 		},
+		"eslint-plugin-ava": {
+			"version": "13.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-ava/-/eslint-plugin-ava-13.2.0.tgz",
+			"integrity": "sha512-i5B5izsEdERKQLruk1nIWzTTE7C26/ju8qQf7JeyRv32XT2lRMW0zMFZNhIrEf5/5VvpSz2rqrV7UcjClGbKsw==",
+			"dev": true,
+			"requires": {
+				"enhance-visitors": "^1.0.0",
+				"eslint-utils": "^3.0.0",
+				"espree": "^9.0.0",
+				"espurify": "^2.1.1",
+				"import-modules": "^2.1.0",
+				"micro-spelling-correcter": "^1.1.1",
+				"pkg-dir": "^5.0.0",
+				"resolve-from": "^5.0.0"
+			},
+			"dependencies": {
+				"find-up": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+					"dev": true,
+					"requires": {
+						"locate-path": "^6.0.0",
+						"path-exists": "^4.0.0"
+					}
+				},
+				"locate-path": {
+					"version": "6.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+					"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^5.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+					"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+					"dev": true,
+					"requires": {
+						"yocto-queue": "^0.1.0"
+					}
+				},
+				"p-locate": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+					"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^3.0.2"
+					}
+				},
+				"pkg-dir": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz",
+					"integrity": "sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==",
+					"dev": true,
+					"requires": {
+						"find-up": "^5.0.0"
+					}
+				},
+				"resolve-from": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+					"integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+					"dev": true
+				}
+			}
+		},
 		"eslint-plugin-jsdoc": {
 			"version": "37.9.7",
 			"resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-37.9.7.tgz",
@@ -9179,6 +9411,12 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+			"dev": true
+		},
+		"espurify": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/espurify/-/espurify-2.1.1.tgz",
+			"integrity": "sha512-zttWvnkhcDyGOhSH4vO2qCBILpdCMv/MX8lp4cqgRkQoDRGK2oZxi2GfWhlP2dIXmk7BaKeOTuzbHhyC68o8XQ==",
 			"dev": true
 		},
 		"esquery": {
@@ -9660,6 +9898,12 @@
 				"pkg-dir": "^4.2.0",
 				"resolve-cwd": "^3.0.0"
 			}
+		},
+		"import-modules": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/import-modules/-/import-modules-2.1.0.tgz",
+			"integrity": "sha512-8HEWcnkbGpovH9yInoisxaSoIg9Brbul+Ju3Kqe2UsYDUBJD/iQjSgEj0zPcTDPKfPp2fs5xlv1i+JSye/m1/A==",
+			"dev": true
 		},
 		"imurmurhash": {
 			"version": "0.1.4",
@@ -10412,6 +10656,12 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="
+		},
+		"micro-spelling-correcter": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/micro-spelling-correcter/-/micro-spelling-correcter-1.1.1.tgz",
+			"integrity": "sha512-lkJ3Rj/mtjlRcHk6YyCbvZhyWTOzdBvTHsxMmZSk5jxN1YyVSQ+JETAom55mdzfcyDrY/49Z7UCW760BK30crg==",
+			"dev": true
 		},
 		"micromatch": {
 			"version": "4.0.5",
@@ -12443,6 +12693,12 @@
 					"dev": true
 				}
 			}
+		},
+		"yocto-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+			"dev": true
 		}
 	}
 }

--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
 		"eslint": "^8.7.0",
 		"eslint-config-google": "^0.14.0",
 		"eslint-plugin-jsdoc": "^37.6.3",
+		"eslint-plugin-ava": "^13.2.0",
 		"jsdoc": "^3.6.7",
 		"mock-require": "^3.0.3",
 		"nyc": "^15.1.0",

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -85,9 +85,8 @@ test("Resource: getStream", async (t) => {
 		buffer: Buffer.from("Content")
 	});
 
-	return readStream(resource.getStream()).then((result) => {
-		t.is(result, "Content", "Stream has been read correctly");
-	});
+	const result = await readStream(resource.getStream());
+	t.is(result, "Content", "Stream has been read correctly");
 });
 
 test("Resource: getStream for empty string", async (t) => {
@@ -98,9 +97,8 @@ test("Resource: getStream for empty string", async (t) => {
 		string: ""
 	});
 
-	return readStream(resource.getStream()).then((result) => {
-		t.is(result, "", "Stream has been read correctly for empty string");
-	});
+	const result = await readStream(resource.getStream());
+	t.is(result, "", "Stream has been read correctly for empty string");
 });
 
 test("Resource: getStream for empty string instance", async (t) => {
@@ -112,9 +110,8 @@ test("Resource: getStream for empty string instance", async (t) => {
 		string: new String("")
 	});
 
-	return readStream(resource.getStream()).then((result) => {
-		t.is(result, "", "Stream has been read correctly for empty string");
-	});
+	const result = await readStream(resource.getStream());
+	t.is(result, "", "Stream has been read correctly for empty string");
 });
 
 test("Resource: getStream throwing an error", (t) => {
@@ -269,7 +266,7 @@ test("Resource: setStream (Create stream callback)", async (t) => {
 	t.is(value, "I am a readable stream!", "Stream set correctly");
 });
 
-test("Resource: clone resource with buffer", (t) => {
+test("Resource: clone resource with buffer", async (t) => {
 	t.plan(2);
 
 	const resource = new Resource({
@@ -277,15 +274,14 @@ test("Resource: clone resource with buffer", (t) => {
 		buffer: Buffer.from("Content")
 	});
 
-	return resource.clone().then(function(clonedResource) {
-		t.pass("Resource cloned");
-		return clonedResource.getString().then(function(value) {
-			t.is(value, "Content", "Cloned resource has correct content string");
-		});
-	});
+	const clonedResource = await resource.clone();
+	t.pass("Resource cloned");
+
+	const clonedResourceContent = await clonedResource.getString();
+	t.is(clonedResourceContent, "Content", "Cloned resource has correct content string");
 });
 
-test("Resource: clone resource with stream", (t) => {
+test("Resource: clone resource with stream", async (t) => {
 	t.plan(2);
 
 	const resource = new Resource({
@@ -298,12 +294,11 @@ test("Resource: clone resource with stream", (t) => {
 
 	resource.setStream(stream);
 
-	return resource.clone().then(function(clonedResource) {
-		t.pass("Resource cloned");
-		return clonedResource.getString().then(function(value) {
-			t.is(value, "Content", "Cloned resource has correct content string");
-		});
-	});
+	const clonedResource = await resource.clone();
+	t.pass("Resource cloned");
+
+	const clonedResourceContent = await clonedResource.getString();
+	t.is(clonedResourceContent, "Content", "Cloned resource has correct content string");
 });
 
 test("getStream with createStream callback content: Subsequent content requests should throw error due " +

--- a/test/lib/ResourceFacade.js
+++ b/test/lib/ResourceFacade.js
@@ -3,11 +3,11 @@ const sinon = require("sinon");
 const Resource = require("../../lib/Resource");
 const ResourceFacade = require("../../lib/ResourceFacade");
 
-test.afterEach.always(async (t) => {
+test.afterEach.always( (t) => {
 	sinon.restore();
 });
 
-test("Create instance", async (t) => {
+test("Create instance", (t) => {
 	const resource = new Resource({
 		path: "my/path/to/resource",
 		string: "my content"
@@ -20,7 +20,7 @@ test("Create instance", async (t) => {
 	t.is(resourceFacade.getConcealedResource(), resource, "Returns correct concealed resource");
 });
 
-test("Create instance: Missing parameters", async (t) => {
+test("Create instance: Missing parameters", (t) => {
 	t.throws(() => {
 		new ResourceFacade({
 			path: "my/path",
@@ -54,7 +54,7 @@ test("ResourceFacade #clone", async (t) => {
 	t.is(clone.getPath(), "my/path", "Cloned resource has path of resource facade");
 });
 
-test("ResourceFacade #setPath", async (t) => {
+test("ResourceFacade #setPath", (t) => {
 	const resource = new Resource({
 		path: "my/path/to/resource",
 		string: "my content"
@@ -70,7 +70,7 @@ test("ResourceFacade #setPath", async (t) => {
 	t.is(err.message, "The path of a ResourceFacade can't be changed", "Threw with expected error message");
 });
 
-test("ResourceFacade provides same public functions as Resource", async (t) => {
+test("ResourceFacade provides same public functions as Resource", (t) => {
 	const resource = new Resource({
 		path: "my/path/to/resource",
 		string: "my content"

--- a/test/lib/WriterCollection.js
+++ b/test/lib/WriterCollection.js
@@ -3,7 +3,7 @@ const sinon = require("sinon");
 const WriterCollection = require("../../lib/WriterCollection");
 const Resource = require("../../lib/Resource");
 
-test("Constructor: Path mapping regex", async (t) => {
+test("Constructor: Path mapping regex", (t) => {
 	const myWriter = {};
 	const writer = new WriterCollection({
 		name: "myCollection",
@@ -17,7 +17,7 @@ test("Constructor: Path mapping regex", async (t) => {
 		"Created correct path mapping regular expression");
 });
 
-test("Constructor: Path mapping regex has correct escaping", async (t) => {
+test("Constructor: Path mapping regex has correct escaping", (t) => {
 	const myWriter = {};
 	const writer = new WriterCollection({
 		name: "myCollection",
@@ -31,7 +31,7 @@ test("Constructor: Path mapping regex has correct escaping", async (t) => {
 		"Created correct path mapping regular expression");
 });
 
-test("Constructor: Throws for missing path mapping", async (t) => {
+test("Constructor: Throws for missing path mapping", (t) => {
 	const err = t.throws(() => {
 		new WriterCollection({
 			name: "myCollection"
@@ -40,7 +40,7 @@ test("Constructor: Throws for missing path mapping", async (t) => {
 	t.is(err.message, "Missing parameter 'writerMapping'", "Threw with expected error message");
 });
 
-test("Constructor: Throws for empty path mapping", async (t) => {
+test("Constructor: Throws for empty path mapping", (t) => {
 	const err = t.throws(() => {
 		new WriterCollection({
 			name: "myCollection",
@@ -50,7 +50,7 @@ test("Constructor: Throws for empty path mapping", async (t) => {
 	t.is(err.message, "Empty parameter 'writerMapping'", "Threw with expected error message");
 });
 
-test("Constructor: Throws for empty path", async (t) => {
+test("Constructor: Throws for empty path", (t) => {
 	const myWriter = {
 		_write: sinon.stub()
 	};
@@ -66,7 +66,7 @@ test("Constructor: Throws for empty path", async (t) => {
 		"Threw with expected error message");
 });
 
-test("Constructor: Throws for missing leading slash", async (t) => {
+test("Constructor: Throws for missing leading slash", (t) => {
 	const myWriter = {
 		_write: sinon.stub()
 	};
@@ -82,7 +82,7 @@ test("Constructor: Throws for missing leading slash", async (t) => {
 		"Threw with expected error message");
 });
 
-test("Constructor: Throws for missing trailing slash", async (t) => {
+test("Constructor: Throws for missing trailing slash", (t) => {
 	const myWriter = {
 		_write: sinon.stub()
 	};

--- a/test/lib/adapters/FileSystem_read.js
+++ b/test/lib/adapters/FileSystem_read.js
@@ -8,7 +8,7 @@ test("glob resources from application.a w/ virtual base path prefix", async (t) 
 	});
 
 	const resources = await readerWriter.byGlob("/app/**/*.html");
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob resources from application.a w/o virtual base path prefix", async (t) => {
@@ -18,7 +18,7 @@ test("glob resources from application.a w/o virtual base path prefix", async (t)
 	});
 
 	const resources = await readerWriter.byGlob("/**/*.html");
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob virtual directory w/o virtual base path prefix", async (t) => {
@@ -28,7 +28,7 @@ test("glob virtual directory w/o virtual base path prefix", async (t) => {
 	});
 
 	const resources = await readerWriter.byGlob("/*", {nodir: false});
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob virtual directory w/o virtual base path prefix and multiple patterns", async (t) => {
@@ -41,7 +41,7 @@ test("glob virtual directory w/o virtual base path prefix and multiple patterns"
 		"/*",
 		"/*"
 	], {nodir: false});
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob virtual directory w/ virtual base path prefix", async (t) => {
@@ -51,7 +51,7 @@ test("glob virtual directory w/ virtual base path prefix", async (t) => {
 	});
 
 	const resources = await readerWriter.byGlob("/app/*", {nodir: false});
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob virtual directory w/o virtual base path prefix and nodir: true", async (t) => {
@@ -61,7 +61,7 @@ test("glob virtual directory w/o virtual base path prefix and nodir: true", asyn
 	});
 
 	const resources = await readerWriter.byGlob("/*", {nodir: true});
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("glob virtual directory w/o virtual base path prefix and nodir: true and multiple patterns", async (t) => {
@@ -74,7 +74,7 @@ test("glob virtual directory w/o virtual base path prefix and nodir: true and mu
 		"/*",
 		"/*"
 	], {nodir: true});
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("glob virtual directory w/ virtual base path prefix and nodir: true", async (t) => {
@@ -84,7 +84,7 @@ test("glob virtual directory w/ virtual base path prefix and nodir: true", async
 	});
 
 	const resources = await readerWriter.byGlob("/app/*", {nodir: true});
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("glob resources from application.a with directory exclude", async (t) => {
@@ -94,7 +94,7 @@ test("glob resources from application.a with directory exclude", async (t) => {
 	});
 
 	await readerWriter.byGlob("/!(pony,unicorn)/**").then(function(resources) {
-		t.deepEqual(resources.length, 2, "Found exactly two resource");
+		t.is(resources.length, 2, "Found exactly two resource");
 	});
 });
 
@@ -136,12 +136,12 @@ test("static excludes: glob library src and test", async (t) => {
 	const srcResources = await srcReader.byGlob("/**/*", {nodir: true});
 	const testResources = await testReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(srcResources.length, 1, "Found one src resource");
+	t.is(srcResources.length, 1, "Found one src resource");
 	t.deepEqual(srcResources.map(getPathFromResource), [
 		"/resources/library/l/.library"
 	], "Found expected src resources");
 
-	t.deepEqual(testResources.length, 0, "Found no test resources");
+	t.is(testResources.length, 0, "Found no test resources");
 });
 
 test("static excludes: glob library src and test with double negation", async (t) => {
@@ -167,12 +167,12 @@ test("static excludes: glob library src and test with double negation", async (t
 	const srcResources = await srcReader.byGlob("/**/*", {nodir: true});
 	const testResources = await testReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(srcResources.length, 1, "Found one src resource");
+	t.is(srcResources.length, 1, "Found one src resource");
 	t.deepEqual(srcResources.map(getPathFromResource), [
 		"/resources/library/l/.library"
 	], "Found expected src resources");
 
-	t.deepEqual(testResources.length, 1, "Found one test resource");
+	t.is(testResources.length, 1, "Found one test resource");
 	t.deepEqual(testResources.map(getPathFromResource), [
 		"/test-resources/library/l/Test2.html"
 	], "Found expected test resources");
@@ -194,7 +194,7 @@ test("static excludes: glob library test with double negation", async (t) => {
 
 	const testResources = await testReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(testResources.length, 1, "Found one test resource");
+	t.is(testResources.length, 1, "Found one test resource");
 	t.deepEqual(testResources.map(getPathFromResource), [
 		"/test-resources/library/l/Test2.html"
 	], "Found expected test resources");
@@ -211,7 +211,7 @@ test("static excludes: glob with virtual root exclude", async (t) => {
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("static excludes: glob with negated directory exclude, excluding resources", async (t) => {
@@ -225,7 +225,7 @@ test("static excludes: glob with negated directory exclude, excluding resources"
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("static excludes: glob with negated directory exclude, not excluding resources", async (t) => {
@@ -239,7 +239,7 @@ test("static excludes: glob with negated directory exclude, not excluding resour
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(resources.length, 2, "Found two resources");
+	t.is(resources.length, 2, "Found two resources");
 });
 
 test("static excludes: byPath exclude everything in sub-directory", async (t) => {
@@ -250,7 +250,7 @@ test("static excludes: byPath exclude everything in sub-directory", async (t) =>
 	});
 
 	const resource = await readerWriter.byPath("/resources/app/index.html", {nodir: true});
-	t.deepEqual(resource, null, "Found no resource");
+	t.is(resource, null, "Found no resource");
 });
 
 test("static excludes: byPath exclude with negation", async (t) => {
@@ -278,7 +278,7 @@ test("static excludes: byPath exclude with unused negation", async (t) => {
 	});
 
 	const resource = await readerWriter.byPath("/resources/app/index.html", {nodir: true});
-	t.deepEqual(resource, null, "Resource is excluded");
+	t.is(resource, null, "Resource is excluded");
 });
 
 test("static excludes: byPath exclude with negated directory pattern, excluding resources", async (t) => {
@@ -291,7 +291,7 @@ test("static excludes: byPath exclude with negated directory pattern, excluding 
 	});
 
 	const resource = await readerWriter.byPath("/resources/app/index.html", {nodir: true});
-	t.deepEqual(resource, null, "Found no resource");
+	t.is(resource, null, "Found no resource");
 });
 
 test("static excludes: byPath exclude with negated directory pattern, not excluding resources", async (t) => {
@@ -324,8 +324,8 @@ test("byPath: exclude with unused negation", async (t) => {
 		readerWriter.byPath("/resources/app/i18n/i18n.properties", {nodir: true})
 	]);
 	t.truthy(manifest, "Found manifest.json resource");
-	t.deepEqual(i18n, null, "i18n resource is excluded");
-	t.deepEqual(i18ni18n, null, "i18n in i18n directory resource is excluded");
+	t.is(i18n, null, "i18n resource is excluded");
+	t.is(i18ni18n, null, "i18n in i18n directory resource is excluded");
 });
 
 test("static excludes: glob library src and test with double negation (nodir: false)", async (t) => {
@@ -351,9 +351,9 @@ test("static excludes: glob library src and test with double negation (nodir: fa
 	const srcResources = await srcReader.byGlob("/**/*", {nodir: false});
 	const testResources = await testReader.byGlob("/**/*", {nodir: false});
 
-	t.deepEqual(srcResources.length, 3, "Found one src resource and two directories");
+	t.is(srcResources.length, 3, "Found one src resource and two directories");
 
-	t.deepEqual(testResources.length, 1, "Found one test resource");
+	t.is(testResources.length, 1, "Found one test resource");
 	t.deepEqual(testResources.map(getPathFromResource), [
 		"/test-resources/library/l/Test2.html"
 	], "Found expected test resources");
@@ -370,7 +370,7 @@ test("static excludes: glob with virtual root exclude (nodir: false)", async (t)
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: false});
 
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 test("static excludes: glob with negated directory exclude, excluding resources (nodir: false)", async (t) => {
 	const srcReader = resourceFactory.createAdapter({
@@ -383,7 +383,7 @@ test("static excludes: glob with negated directory exclude, excluding resources 
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: false});
 
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("static excludes: glob with negated directory exclude, not excluding resources (nodir: false)", async (t) => {
@@ -397,5 +397,5 @@ test("static excludes: glob with negated directory exclude, not excluding resour
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: false});
 
-	t.deepEqual(resources.length, 4, "Found two resources and two directories");
+	t.is(resources.length, 4, "Found two resources and two directories");
 });

--- a/test/lib/adapters/Memory_read.js
+++ b/test/lib/adapters/Memory_read.js
@@ -41,7 +41,7 @@ test("glob resources from application.a w/ virtual base path prefix", async (t) 
 	await readerWriter.write(resource);
 
 	const resources = await readerWriter.byGlob("/app/*.html");
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob resources from application.a w/o virtual base path prefix", async (t) => {
@@ -56,7 +56,7 @@ test("glob resources from application.a w/o virtual base path prefix", async (t)
 	await readerWriter.write(resource);
 
 	const resources = await readerWriter.byGlob("/**/*.html");
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob virtual directory w/o virtual base path prefix", async (t) => {
@@ -66,7 +66,7 @@ test("glob virtual directory w/o virtual base path prefix", async (t) => {
 	});
 
 	const resources = await readerWriter.byGlob("/*", {nodir: false});
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob virtual directory w/o virtual base path prefix and multiple patterns", async (t) => {
@@ -79,7 +79,7 @@ test("glob virtual directory w/o virtual base path prefix and multiple patterns"
 		"/*",
 		"/*"
 	], {nodir: false});
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob virtual directory w/ virtual base path prefix", async (t) => {
@@ -89,7 +89,7 @@ test("glob virtual directory w/ virtual base path prefix", async (t) => {
 	});
 
 	const resources = await readerWriter.byGlob("/app/*", {nodir: false});
-	t.deepEqual(resources.length, 1, "Found exactly one resource");
+	t.is(resources.length, 1, "Found exactly one resource");
 });
 
 test("glob virtual directory w/o virtual base path prefix and nodir: true", async (t) => {
@@ -98,7 +98,7 @@ test("glob virtual directory w/o virtual base path prefix and nodir: true", asyn
 	});
 
 	const resources = await readerWriter.byGlob("/*", {nodir: true});
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("glob virtual directory w/ virtual base path prefix and nodir: true", async (t) => {
@@ -107,7 +107,7 @@ test("glob virtual directory w/ virtual base path prefix and nodir: true", async
 	});
 
 	const resources = await readerWriter.byGlob("/app/*", {nodir: true});
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("glob virtual directory w/ virtual base path prefix and nodir: true and multiple patterns", async (t) => {
@@ -119,7 +119,7 @@ test("glob virtual directory w/ virtual base path prefix and nodir: true and mul
 		"/*",
 		"/*"
 	], {nodir: true});
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 /* Load more data from FS into memory */
@@ -129,7 +129,7 @@ test("glob all", async (t) => {
 	});
 	await fillFromFs(readerWriter);
 	const resources = await readerWriter.byGlob("/**/*.*");
-	t.deepEqual(resources.length, 16, "Found all resources");
+	t.is(resources.length, 16, "Found all resources");
 });
 
 test("glob all from root", async (t) => {
@@ -149,7 +149,7 @@ test("glob all with virtual path included", async (t) => {
 	await fillFromFs(readerWriter);
 
 	const resources = await readerWriter.byGlob("/app/**/*.*");
-	t.deepEqual(resources.length, 16, "Found all resources");
+	t.is(resources.length, 16, "Found all resources");
 });
 
 test("glob a specific filetype (yaml)", async (t) => {
@@ -161,7 +161,7 @@ test("glob a specific filetype (yaml)", async (t) => {
 
 	const resources = await readerWriter.byGlob("/**/*.yaml");
 	resources.forEach((res) => {
-		t.deepEqual(res._name, "ui5.yaml");
+		t.is(res._name, "ui5.yaml");
 	});
 });
 
@@ -225,8 +225,8 @@ test("glob (normalized) root directory (=> fs root)", async (t) => {
 		"/*",
 	], {nodir: false});
 	resources.forEach((res) => {
-		t.deepEqual(res._name, "app");
-		t.deepEqual(res.getStatInfo().isDirectory(), true);
+		t.is(res._name, "app");
+		t.is(res.getStatInfo().isDirectory(), true);
 	});
 });
 
@@ -252,9 +252,9 @@ test("glob subdirectory", async (t) => {
 		"/app/application.a",
 	], {nodir: false});
 
-	t.deepEqual(resources.length, 1, "Found one resource");
-	t.deepEqual(resources[0].getPath(), "/app/application.a");
-	t.deepEqual(resources[0].getStatInfo().isDirectory(), true);
+	t.is(resources.length, 1, "Found one resource");
+	t.is(resources[0].getPath(), "/app/application.a");
+	t.is(resources[0].getStatInfo().isDirectory(), true);
 });
 
 
@@ -292,12 +292,12 @@ test("static excludes: glob library src and test", async (t) => {
 	const srcResources = await srcReader.byGlob("/**/*", {nodir: true});
 	const testResources = await testReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(srcResources.length, 1, "Found one src resource");
+	t.is(srcResources.length, 1, "Found one src resource");
 	t.deepEqual(srcResources.map(getPathFromResource), [
 		"/resources/library/l/.library"
 	], "Found expected src resources");
 
-	t.deepEqual(testResources.length, 0, "Found no test resources");
+	t.is(testResources.length, 0, "Found no test resources");
 });
 
 test("static excludes: glob library src and test with double negation", async (t) => {
@@ -329,12 +329,12 @@ test("static excludes: glob library src and test with double negation", async (t
 	const srcResources = await srcReader.byGlob("/**/*", {nodir: true});
 	const testResources = await testReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(srcResources.length, 1, "Found one src resource");
+	t.is(srcResources.length, 1, "Found one src resource");
 	t.deepEqual(srcResources.map(getPathFromResource), [
 		"/resources/library/l/.library"
 	], "Found expected src resources");
 
-	t.deepEqual(testResources.length, 1, "Found one test resource");
+	t.is(testResources.length, 1, "Found one test resource");
 	t.deepEqual(testResources.map(getPathFromResource), [
 		"/test-resources/library/l/Test2.html"
 	], "Found expected test resources");
@@ -359,7 +359,7 @@ test("static excludes: glob library test with double negation", async (t) => {
 
 	const testResources = await testReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(testResources.length, 1, "Found one test resource");
+	t.is(testResources.length, 1, "Found one test resource");
 	t.deepEqual(testResources.map(getPathFromResource), [
 		"/test-resources/library/l/Test2.html"
 	], "Found expected test resources");
@@ -379,7 +379,7 @@ test("static excludes: glob with virtual root exclude", async (t) => {
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("static excludes: glob with negated directory exclude, excluding resources", async (t) => {
@@ -396,7 +396,7 @@ test("static excludes: glob with negated directory exclude, excluding resources"
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("static excludes: glob with negated directory exclude, not excluding resources", async (t) => {
@@ -413,7 +413,7 @@ test("static excludes: glob with negated directory exclude, not excluding resour
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: true});
 
-	t.deepEqual(resources.length, 2, "Found two resources");
+	t.is(resources.length, 2, "Found two resources");
 });
 
 test("static excludes: byPath exclude everything in sub-directory", async (t) => {
@@ -427,7 +427,7 @@ test("static excludes: byPath exclude everything in sub-directory", async (t) =>
 	});
 
 	const resource = await readerWriter.byPath("/resources/app/index.html", {nodir: true});
-	t.deepEqual(resource, null, "Found no resource");
+	t.is(resource, null, "Found no resource");
 });
 
 test("static excludes: byPath exclude with negation", async (t) => {
@@ -461,7 +461,7 @@ test("static excludes: byPath exclude with unused negation", async (t) => {
 	});
 
 	const resource = await readerWriter.byPath("/resources/app/index.html", {nodir: true});
-	t.deepEqual(resource, null, "Resource is excluded");
+	t.is(resource, null, "Resource is excluded");
 });
 
 test("static excludes: byPath exclude with negated directory pattern, excluding resources", async (t) => {
@@ -477,7 +477,7 @@ test("static excludes: byPath exclude with negated directory pattern, excluding 
 	});
 
 	const resource = await readerWriter.byPath("/resources/app/index.html", {nodir: true});
-	t.deepEqual(resource, null, "Found no resource");
+	t.is(resource, null, "Found no resource");
 });
 
 test("static excludes: byPath exclude with negated directory pattern, not excluding resources", async (t) => {
@@ -516,8 +516,8 @@ test("byPath: exclude with unused negation", async (t) => {
 		readerWriter.byPath("/resources/app/i18n/i18n.properties", {nodir: true})
 	]);
 	t.truthy(manifest, "Found manifest.json resource");
-	t.deepEqual(i18n, null, "i18n resource is excluded");
-	t.deepEqual(i18ni18n, null, "i18n in i18n directory resource is excluded");
+	t.is(i18n, null, "i18n resource is excluded");
+	t.is(i18ni18n, null, "i18n in i18n directory resource is excluded");
 });
 
 test("static excludes: glob library src and test with double negation (nodir: false)", async (t) => {
@@ -549,9 +549,9 @@ test("static excludes: glob library src and test with double negation (nodir: fa
 	const srcResources = await srcReader.byGlob("/**/*", {nodir: false});
 	const testResources = await testReader.byGlob("/**/*", {nodir: false});
 
-	t.deepEqual(srcResources.length, 3, "Found one src resource and two directories");
+	t.is(srcResources.length, 3, "Found one src resource and two directories");
 
-	t.deepEqual(testResources.length, 1, "Found one test resource");
+	t.is(testResources.length, 1, "Found one test resource");
 	t.deepEqual(testResources.map(getPathFromResource), [
 		"/test-resources/library/l/Test2.html"
 	], "Found expected test resources");
@@ -571,7 +571,7 @@ test("static excludes: glob with virtual root exclude (nodir: false)", async (t)
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: false});
 
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 test("static excludes: glob with negated directory exclude, excluding resources (nodir: false)", async (t) => {
 	const srcReader = resourceFactory.createAdapter({
@@ -587,7 +587,7 @@ test("static excludes: glob with negated directory exclude, excluding resources 
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: false});
 
-	t.deepEqual(resources.length, 0, "Found no resources");
+	t.is(resources.length, 0, "Found no resources");
 });
 
 test("static excludes: glob with negated directory exclude, not excluding resources (nodir: false)", async (t) => {
@@ -604,5 +604,5 @@ test("static excludes: glob with negated directory exclude, not excluding resour
 
 	const resources = await srcReader.byGlob("/**/*", {nodir: false});
 
-	t.deepEqual(resources.length, 4, "Found two resources and two directories");
+	t.is(resources.length, 4, "Found two resources and two directories");
 });

--- a/test/lib/adapters/Memory_write.js
+++ b/test/lib/adapters/Memory_write.js
@@ -12,7 +12,7 @@ test("glob resources from application.a w/ virtual base path prefix", async (t) 
 	await dest.write(res)
 		.then(() => dest.byGlob("/app/*.html"))
 		.then((resources) => {
-			t.deepEqual(resources.length, 1, "Found exactly one resource");
+			t.is(resources.length, 1, "Found exactly one resource");
 		});
 });
 
@@ -27,7 +27,7 @@ test("glob resources from application.a w/o virtual base path prefix", async (t)
 	await dest.write(res)
 		.then(() => dest.byGlob("/**/*.html"))
 		.then((resources) => {
-			t.deepEqual(resources.length, 1, "Found exactly one resource");
+			t.is(resources.length, 1, "Found exactly one resource");
 		});
 });
 
@@ -69,8 +69,8 @@ test("Write resource w/o virtual base path", async (t) => {
 	], "Adapter added correct virtual directories");
 
 	const dirRes = readerWriter._virDirs["one/two/three"];
-	t.deepEqual(dirRes.getStatInfo().isDirectory(), true, "Directory resource is a directory");
-	t.deepEqual(dirRes.getPath(), "/one/two/three", "Directory resource has correct path");
+	t.is(dirRes.getStatInfo().isDirectory(), true, "Directory resource is a directory");
+	t.is(dirRes.getPath(), "/one/two/three", "Directory resource has correct path");
 });
 
 test("Write resource w/ deep virtual base path", async (t) => {
@@ -94,8 +94,8 @@ test("Write resource w/ deep virtual base path", async (t) => {
 	], "Adapter added correct virtual directories");
 
 	const dirRes = readerWriter._virDirs["one/two/three"];
-	t.deepEqual(dirRes.getStatInfo().isDirectory(), true, "Directory resource is a directory");
-	t.deepEqual(dirRes.getPath(), "/app/a/one/two/three", "Directory resource has correct path");
+	t.is(dirRes.getStatInfo().isDirectory(), true, "Directory resource is a directory");
+	t.is(dirRes.getPath(), "/app/a/one/two/three", "Directory resource has correct path");
 });
 
 test("Write resource w/ crazy virtual base path", async (t) => {

--- a/test/lib/readers/Filter.js
+++ b/test/lib/readers/Filter.js
@@ -41,7 +41,7 @@ test("_byPath: Negative filter", async (t) => {
 	});
 
 	const resource = await readerCollection._byPath("anyPattern", {}, trace);
-	t.deepEqual(resource, null, "Correct empty result");
+	t.is(resource, null, "Correct empty result");
 });
 
 test("_byPath: Positive filter", async (t) => {
@@ -62,5 +62,5 @@ test("_byPath: Positive filter", async (t) => {
 	});
 
 	const resource = await readerCollection._byPath("anyPattern", {}, trace);
-	t.deepEqual(resource, "resource b", "Correct resource in result");
+	t.is(resource, "resource b", "Correct resource in result");
 });

--- a/test/lib/readers/Link.js
+++ b/test/lib/readers/Link.js
@@ -155,7 +155,7 @@ test("_byPath: Basic Link", async (t) => {
 	t.is(resource.getPath(), "/dir/File.js", "First resource has correct rewritten path");
 
 	t.is(abstractReader._byPath.callCount, 1, "Mocked _byPath got called once");
-	t.deepEqual(abstractReader._byPath.getCall(0).args[0], "/resources/some/lib/dir/File.js",
+	t.is(abstractReader._byPath.getCall(0).args[0], "/resources/some/lib/dir/File.js",
 		"Mocked _byPath got called with expected patterns");
 	t.is(abstractReader._byPath.getCall(0).args[1], options,
 		"Mocked _byPath got called with expected options");
@@ -188,7 +188,7 @@ test("_byPath: Rewrite on same level", async (t) => {
 	t.is(resource.getPath(), "/my/lib/dir/File.js", "First resource has correct rewritten path");
 
 	t.is(abstractReader._byPath.callCount, 1, "Mocked _byPath got called once");
-	t.deepEqual(abstractReader._byPath.getCall(0).args[0], "/some/lib/dir/File.js",
+	t.is(abstractReader._byPath.getCall(0).args[0], "/some/lib/dir/File.js",
 		"Mocked _byPath got called with expected patterns");
 	t.is(abstractReader._byPath.getCall(0).args[1], options,
 		"Mocked _byPath got called with expected options");
@@ -216,7 +216,7 @@ test("_byPath: No resource found", async (t) => {
 	t.is(resource, null, "No resource returned");
 
 	t.is(abstractReader._byPath.callCount, 1, "Mocked _byPath got called once");
-	t.deepEqual(abstractReader._byPath.getCall(0).args[0], "/some/lib/dir/File.js",
+	t.is(abstractReader._byPath.getCall(0).args[0], "/some/lib/dir/File.js",
 		"Mocked _byPath got called with expected patterns");
 	t.is(abstractReader._byPath.getCall(0).args[1], options,
 		"Mocked _byPath got called with expected options");
@@ -245,7 +245,7 @@ test("_byPath: Request different prefix", async (t) => {
 	t.is(abstractReader._byPath.callCount, 0, "Mocked _byPath never got called");
 });
 
-test("Missing attributes", async (t) => {
+test("Missing attributes", (t) => {
 	const abstractReader = {};
 	let err = t.throws(() => {
 		new Link({

--- a/test/lib/readers/Transformer.js
+++ b/test/lib/readers/Transformer.js
@@ -35,11 +35,11 @@ test("_byGlob: Basic transformation", async (t) => {
 	});
 
 	const resources = await readerCollection._byGlob("anyPattern", {}, trace);
-	t.deepEqual(resources.length, 2, "Still two resources in result set");
-	t.deepEqual(resources[0].name, "transformed resource.a", "resource.a has been transformed in result");
-	t.deepEqual(resources[1].name, "resource.b", "resource.b has not been transformed");
+	t.is(resources.length, 2, "Still two resources in result set");
+	t.is(resources[0].name, "transformed resource.a", "resource.a has been transformed in result");
+	t.is(resources[1].name, "resource.b", "resource.b has not been transformed");
 	t.is(resources[1], resourceB, "resource.b instance has not been cloned");
-	t.deepEqual(resourceA.name, "resource.a", "Original resource.a has not been transformed");
+	t.is(resourceA.name, "resource.a", "Original resource.a has not been transformed");
 });
 
 test("_byPath: Basic transformation", async (t) => {
@@ -62,8 +62,8 @@ test("_byPath: Basic transformation", async (t) => {
 
 	const resource = await readerCollection._byPath("anyPattern", {}, trace);
 
-	t.deepEqual(resource.name, "transformed resource.a", "resource.a has been transformed in result");
-	t.deepEqual(resourceA.name, "resource.a", "Original resource.a has not been transformed");
+	t.is(resource.name, "transformed resource.a", "resource.a has been transformed in result");
+	t.is(resourceA.name, "resource.a", "Original resource.a has not been transformed");
 });
 
 test("_byPath: No transformation", async (t) => {
@@ -82,6 +82,6 @@ test("_byPath: No transformation", async (t) => {
 	});
 
 	const resource = await readerCollection._byPath("anyPattern", {}, trace);
-	t.deepEqual(resource.name, "resource.b", "Correct resource in result");
+	t.is(resource.name, "resource.b", "Correct resource in result");
 	t.is(resource, resourceB, "resource.b instance has not been cloned");
 });

--- a/test/lib/resourceFactory.js
+++ b/test/lib/resourceFactory.js
@@ -7,7 +7,7 @@ const ReaderCollection = require("../../lib/ReaderCollection");
 // Set log level to silly to activate tracing
 require("@ui5/logger").setLevel("silly");
 
-test("prefixGlobPattern", async (t) => {
+test("prefixGlobPattern", (t) => {
 	t.deepEqual(
 		resourceFactory.prefixGlobPattern("{/sub-directory-1/,/sub-directory-2/}**", "/pony/path/a"),
 		[

--- a/test/lib/tracing/traceSummary.js
+++ b/test/lib/tracing/traceSummary.js
@@ -51,7 +51,7 @@ test.serial("traceSummary", async (t) => {
 	// Print reporting and reset tracing
 	await traceSummary.traceEnded();
 
-	t.deepEqual(myLoggerInstance.silly.callCount, 1, "Logger has been called exactly once");
+	t.is(myLoggerInstance.silly.callCount, 1, "Logger has been called exactly once");
 	t.deepEqual(myLoggerInstance.silly.getCall(0).args[0], expectedReport, "Correct report logged to the console");
 });
 
@@ -88,5 +88,5 @@ test.serial("traceSummary no silly logging", async (t) => {
 	// Print reporting and reset tracing
 	await traceSummary.traceEnded();
 
-	t.deepEqual(myLoggerInstance.silly.callCount, 0, "Logger has not been called (due to disabled silly logging)");
+	t.is(myLoggerInstance.silly.callCount, 0, "Logger has not been called (due to disabled silly logging)");
 });


### PR DESCRIPTION
Introducing [eslint-plugin-ava](https://github.com/avajs/eslint-plugin-ava/) to avoid common pitfalls when writing powerful ava tests.

- Add plugin to eslint config and package.json
- Restructure current code base to latest recommendations