### PR TITLE
[INTERNAL] Resource: Add getName function

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -53,7 +53,7 @@ class Resource {
 		}
 
 		this._path = path;
-		this._name = this._getNameFromPath(path);
+		this._name = Resource._getNameFromPath(path);
 
 		this._source = source; // Experimental, internal parameter
 		if (this._source) {
@@ -92,6 +92,10 @@ class Resource {
 
 		// Tracing:
 		this._collections = [];
+	}
+
+	static _getNameFromPath(virPath) {
+		return path.posix.basename(virPath);
 	}
 
 	/**
@@ -244,7 +248,17 @@ class Resource {
 	 */
 	setPath(path) {
 		this._path = path;
-		this._name = this._getNameFromPath(path);
+		this._name = Resource._getNameFromPath(path);
+	}
+
+	/**
+	 * Gets the resource name
+	 *
+	 * @public
+	 * @returns {string} Name of the resource
+	 */
+	getName() {
+		return this._name;
 	}
 
 	/**
@@ -274,10 +288,6 @@ class Resource {
 		}
 		const buffer = await this.getBuffer();
 		return buffer.byteLength;
-	}
-
-	_getNameFromPath(virPath) {
-		return path.posix.basename(virPath);
 	}
 
 	/**

--- a/lib/ResourceFacade.js
+++ b/lib/ResourceFacade.js
@@ -1,3 +1,5 @@
+import Resource from "./Resource.js";
+
 /**
  * A {@link @ui5/fs/Resource Resource} with a different path than it's original
  *
@@ -22,6 +24,7 @@ class ResourceFacade {
 			throw new Error("Cannot create ResourceFacade: resource parameter missing");
 		}
 		this._path = path;
+		this._name = Resource._getNameFromPath(path);
 		this._resource = resource;
 	}
 
@@ -33,6 +36,16 @@ class ResourceFacade {
 	 */
 	getPath() {
 		return this._path;
+	}
+
+	/**
+	 * Gets the resource name
+	 *
+	 * @public
+	 * @returns {string} Name of the resource
+	 */
+	getName() {
+		return this._name;
 	}
 
 	/**

--- a/lib/fsInterface.js
+++ b/lib/fsInterface.js
@@ -79,7 +79,7 @@ function fsInterface(reader) {
 				nodir: false
 			}).then((resources) => {
 				const files = resources.map((resource) => {
-					return resource._name;
+					return resource.getName();
 				});
 				callback(null, files);
 			}).catch(callback);

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -84,6 +84,16 @@ test("Resource: getPath / getName", (t) => {
 	t.is(resource.getName(), "resource.js", "Correct name");
 });
 
+test("Resource: setPath / getName", (t) => {
+	const resource = new Resource({
+		path: "my/path/to/resource.js",
+		buffer: Buffer.from("Content")
+	});
+	resource.setPath("my/other/file.json");
+	t.is(resource.getPath(), "my/other/file.json", "Correct path");
+	t.is(resource.getName(), "file.json", "Correct name");
+});
+
 test("Resource: getStream", async (t) => {
 	t.plan(1);
 

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -75,6 +75,15 @@ test("Resource: getBuffer with throwing an error", (t) => {
 	});
 });
 
+test("Resource: getPath / getName", (t) => {
+	const resource = new Resource({
+		path: "my/path/to/resource.js",
+		buffer: Buffer.from("Content")
+	});
+	t.is(resource.getPath(), "my/path/to/resource.js", "Correct path");
+	t.is(resource.getName(), "resource.js", "Correct name");
+});
+
 test("Resource: getStream", async (t) => {
 	t.plan(1);
 

--- a/test/lib/ResourceFacade.js
+++ b/test/lib/ResourceFacade.js
@@ -17,6 +17,7 @@ test("Create instance", (t) => {
 		resource
 	});
 	t.is(resourceFacade.getPath(), "my/path", "Returns correct path");
+	t.is(resourceFacade.getName(), "path", "Returns correct name");
 	t.is(resourceFacade.getConcealedResource(), resource, "Returns correct concealed resource");
 });
 
@@ -85,7 +86,7 @@ test("ResourceFacade provides same public functions as Resource", (t) => {
 
 	methods.forEach((method) => {
 		t.truthy(resourceFacade[method], `resourceFacade provides function #${method}`);
-		if (["constructor", "getPath", "setPath", "clone"].includes(method)) {
+		if (["constructor", "getPath", "getName", "setPath", "clone"].includes(method)) {
 			// special functions with separate tests
 			return;
 		}


### PR DESCRIPTION
Modules like the "[serveIndex](https://github.com/SAP/ui5-server/blob/e7f64dbecdafae717191ee726f7003b505dcb622/lib/middleware/serveIndex.js#L52)" middleware or the "[fsInterface](https://github.com/SAP/ui5-fs/blob/eea2464bd2a0609a7ee9f4cb17ef08871bbbfbc4/lib/fsInterface.js#L82)" currently
determine the name of a Resource by using the private `_name` attribute.
This is typically required for listing the content of a directory.

This attribute was missing from ResourceFacade, which lead to issues in
both modules.

In addition to adding the missing, private attribute. Also add a public
function getName().