### PR TITLE
[INTERNAL] Remove other than main branch workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -3,14 +3,10 @@ name: "CodeQL"
 on:
   push:
     branches:
-      - v2
       - main
-      - next
   pull_request:
     branches:
-      - v2
       - main
-      - next
 
   # Execute at least once per week to get new findings without active development taking place
   schedule:

--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -3,14 +3,10 @@ name: GitHub CI
 on:
   push:
     branches:
-      - v2
       - main
-      - next
   pull_request:
     branches:
-      - v2
       - main
-      - next
 
 jobs:
   test:

--- a/.github/workflows/reuse-compliance.yml
+++ b/.github/workflows/reuse-compliance.yml
@@ -3,14 +3,10 @@ name: REUSE
 on:
   push:
     branches:
-      - v2
       - main
-      - next
   pull_request:
     branches:
-      - v2
       - main
-      - next
 
 jobs:
   compliance-check:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,6 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
-- v2
 - main
 
 strategy:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,6 +4,7 @@
 # https://docs.microsoft.com/azure/devops/pipelines/languages/javascript
 
 trigger:
+- v2
 - main
 
 strategy:


### PR DESCRIPTION
In the main branch only workflow configurations related to the main branch are stored.
Other release branches will contain their own configuration.

**Exceptions**: 
- `dependabot.yml`: All branches triggering dependabot updates have to be maintained in the default branch "main" configuration
- `azure-pipelines.yml`: All branches triggering azure pipeline flows have to be maintained in the default branch "main" configuration. 