### PR TITLE
[INTERNAL] AbstractReader: Remove obsolete filter and flatten methods

### DIFF
--- a/lib/AbstractReader.js
+++ b/lib/AbstractReader.js
@@ -83,46 +83,6 @@ class AbstractReader {
 	}
 
 	/**
-	 * Create a [Filter-Reader]{@link @ui5/fs/readers/Filter} from the current reader.
-	 *
-	 * @public
-	 * @param {@ui5/fs/readers/Filter~callback} callback
-	 * 				Filter function. Will be called for every resource passed through this reader.
-	 * @returns {Promise<@ui5/fs/readers/Filter>} Promise resolving with filter instance
-	 */
-	async filter(callback) {
-		console.warn("DEPRECATED CALL TO AbstractReader#filter - THIS FUNCTION WILL BE REMOVED IN THE NEXT RELEASE");
-		const {default: Filter} = await import("./readers/Filter.js");
-		return new Filter({
-			reader: this,
-			callback
-		});
-	}
-
-	/**
-	 * Create a [Link-Reader]{@link @ui5/fs/readers/Link} where all requests are prefixed with
-	 * <code>/resources/<namespace></code>.
-	 *
-	 * This simulates "flat" resource access, which is for example common for projects of type
-	 * "application".
-	 *
-	 * @public
-	 * @param {string} namespace Project namespace
-	 * @returns {Promise<@ui5/fs/readers/Link>} Promise resolving with reader instance
-	 */
-	async flatten(namespace) {
-		console.warn("DEPRECATED CALL TO AbstractReader#flatten - THIS FUNCTION WILL BE REMOVED IN THE NEXT RELEASE");
-		const {default: Link} = await import("./readers/Link.js");
-		return new Link({
-			reader: this,
-			pathMapping: {
-				linkPath: `/`,
-				targetPath: `/resources/${namespace}/`
-			}
-		});
-	}
-
-	/**
 	 * Locates resources by one or more glob patterns.
 	 *
 	 * @abstract

--- a/test/lib/resources.js
+++ b/test/lib/resources.js
@@ -37,36 +37,6 @@ test("Get resource from application.a (/index.html) and write it to /dest/ using
 	});
 });
 
-test("Legacy: Filter resources", async (t) => {
-	const source = createAdapter({
-		fsBasePath: "./test/fixtures/application.a/webapp",
-		virBasePath: "/app/"
-	});
-	const filteredSource = await source.filter((resource) => {
-		return resource.getPath().endsWith(".js");
-	});
-	const sourceResources = await source.byGlob("**");
-	t.is(sourceResources.length, 2, "Found two resources in source");
-
-	const resources = await filteredSource.byGlob("**");
-
-	t.is(resources.length, 1, "Found exactly one resource via filter");
-	t.is(resources[0].getPath(), "/app/test.js", "Found correct resource");
-});
-
-test("Legacy: Flatten resources", async (t) => {
-	const source = createAdapter({
-		fsBasePath: "./test/fixtures/application.a/webapp",
-		virBasePath: "/resources/app/"
-	});
-	const transformedSource = await source.flatten("app");
-
-	const resources = await transformedSource.byGlob("**/*.js");
-	t.is(resources.length, 1, "Found one resource via transformer");
-	t.is(resources[0].getPath(), "/test.js", "Found correct resource");
-});
-
-
 test("Filter resources", async (t) => {
 	const source = createAdapter({
 		fsBasePath: "./test/fixtures/application.a/webapp",


### PR DESCRIPTION
They have been moved to resourceFactory in
https://github.com/SAP/ui5-fs/pull/438