### PR TITLE
[INTERNAL] Use native fs.mkdir instead of make-dir

### DIFF
--- a/lib/adapters/FileSystem.js
+++ b/lib/adapters/FileSystem.js
@@ -5,8 +5,8 @@ import {promisify} from "node:util";
 import fs from "graceful-fs";
 const copyFile = promisify(fs.copyFile);
 const chmod = promisify(fs.chmod);
+const mkdir = promisify(fs.mkdir);
 import {globby} from "globby";
-import makeDir from "make-dir";
 import {PassThrough} from "node:stream";
 import AbstractAdapter from "./AbstractAdapter.js";
 
@@ -220,7 +220,7 @@ class FileSystem extends AbstractAdapter {
 		const fsPath = path.join(this._fsBasePath, relPath);
 		const dirPath = path.dirname(fsPath);
 
-		await makeDir(dirPath, {fs});
+		await mkdir(dirPath, {recursive: true});
 
 		const resourceSource = resource.getSource();
 		if (!resourceSource.modified && resourceSource.adapter === "FileSystem" && resourceSource.fsPath) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"escape-string-regexp": "^5.0.0",
 				"globby": "^13.1.2",
 				"graceful-fs": "^4.2.10",
-				"make-dir": "^3.1.0",
 				"micromatch": "^4.0.5",
 				"minimatch": "^5.1.0",
 				"pretty-hrtime": "^1.0.3",
@@ -4454,6 +4453,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
 			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"dev": true,
 			"dependencies": {
 				"semver": "^6.0.0"
 			},
@@ -6190,6 +6190,7 @@
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
 			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true,
 			"bin": {
 				"semver": "bin/semver.js"
 			}
@@ -10766,6 +10767,7 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
 			"integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+			"dev": true,
 			"requires": {
 				"semver": "^6.0.0"
 			}
@@ -11987,7 +11989,8 @@
 		"semver": {
 			"version": "6.3.0",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+			"dev": true
 		},
 		"semver-compare": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -126,7 +126,6 @@
 		"escape-string-regexp": "^5.0.0",
 		"globby": "^13.1.2",
 		"graceful-fs": "^4.2.10",
-		"make-dir": "^3.1.0",
 		"micromatch": "^4.0.5",
 		"minimatch": "^5.1.0",
 		"pretty-hrtime": "^1.0.3",

--- a/test/lib/adapters/FileSystem_write.js
+++ b/test/lib/adapters/FileSystem_write.js
@@ -1,9 +1,7 @@
 import path from "node:path";
 import {promisify} from "node:util";
-import fs from "node:fs";
+import {access as fsAccess, constants as fsConstants, mkdir} from "node:fs/promises";
 import {fileURLToPath} from "node:url";
-const fsAccess = promisify(fs.access);
-import makeDir from "make-dir";
 import test from "ava";
 import rimraf from "rimraf";
 const rimrafp = promisify(rimraf);
@@ -20,7 +18,7 @@ test.beforeEach(async (t) => {
 
 	// Create a tmp directory for every test
 	t.context.tmpDirPath = fileURLToPath(new URL("../../tmp/adapters/FileSystemWrite/" + tmpDirName, import.meta.url));
-	await makeDir(t.context.tmpDirPath);
+	await mkdir(t.context.tmpDirPath, {recursive: true});
 
 	t.context.readerWriters = {
 		source: createAdapter({
@@ -63,8 +61,8 @@ test("Write resource in readOnly mode", async (t) => {
 	// Write resource content to another readerWriter
 	await readerWriters.dest.write(resource, {readOnly: true});
 
-	await t.notThrowsAsync(fsAccess(destFsPath, fs.constants.R_OK), "File can be read");
-	await t.throwsAsync(fsAccess(destFsPath, fs.constants.W_OK),
+	await t.notThrowsAsync(fsAccess(destFsPath, fsConstants.R_OK), "File can be read");
+	await t.throwsAsync(fsAccess(destFsPath, fsConstants.W_OK),
 		{message: /EACCES: permission denied|EPERM: operation not permitted/},
 		"File can not be written");
 


### PR DESCRIPTION
The recursive option is available since Node v10.12, which makes the
use of thirdparty packages obsolete for most use cases.
