### PR TITLE
[BREAKING] Throw an error on write of a resource when path does not match virBasePath of the respective adapter

### DIFF
--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -209,6 +209,10 @@ class AbstractAdapter extends AbstractReaderWriter {
 	}
 
 	_write(resource) {
+		if (!resource.getPath().startsWith(this._virBasePath)) {
+			throw new Error("The path of the resource does not starts with the virBasePath of the adapter");
+		}
+
 		if (this._project) {
 			// Assign project to resource if necessary
 			if (resource.hasProject()) {

--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -210,8 +210,8 @@ class AbstractAdapter extends AbstractReaderWriter {
 
 	_write(resource) {
 		if (!resource.getPath().startsWith(this._virBasePath)) {
-			throw new Error("The path of the resource '" + resource.getPath() + "' does not starts with " +
-				"the configured virtual base path of the adapter '" + this._virBasePath + "'");
+			throw new Error(`The path of the resource '${resource.getPath()}' does not starts with ` +
+				`the configured virtual base path of the adapter '${this._virBasePath}'`);
 		}
 
 		if (this._project) {

--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -210,7 +210,8 @@ class AbstractAdapter extends AbstractReaderWriter {
 
 	_write(resource) {
 		if (!resource.getPath().startsWith(this._virBasePath)) {
-			throw new Error("The path of the resource does not starts with the virBasePath of the adapter");
+			throw new Error("The path of the resource '" + resource.getPath() + "' does not starts with " +
+				"the configured virtual base path of the adapter '" + this._virBasePath + "'");
 		}
 
 		if (this._project) {

--- a/test/lib/adapters/AbstractAdapter.js
+++ b/test/lib/adapters/AbstractAdapter.js
@@ -40,3 +40,23 @@ test("Write resource with another project than provided in the adapter", (t) => 
 	t.is(error.message,
 		"Unable to write resource associated with project test.lib into adapter of project test.lib1: /test.js");
 });
+
+test("Create a resource with a path not starting with path configured in the adapter", (t) => {
+	const resource = createResource({
+		path: "/dest2/tmp/test.js",
+		string: "MyContent"
+	});
+
+	const writer = new MyAbstractAdapter({
+		virBasePath: "/dest2/writer/",
+		project: {
+			getName: () => "test.lib1",
+			getVersion: () => "2.0.0"
+		}
+	});
+
+	const error = t.throws(() => writer._write(resource));
+	t.is(error.message,
+		"The path of the resource '/dest2/tmp/test.js' does not starts with the configured " +
+			"virtual base path of the adapter '/dest2/writer/'");
+});

--- a/test/lib/resources.js
+++ b/test/lib/resources.js
@@ -70,7 +70,7 @@ for (const adapter of adapters) {
 		});
 
 		const resource = createResource({
-			path: "/dest/writer/test.js",
+			path: "/dest/writer/content/test.js",
 			string: "MyInitialContent"
 		});
 
@@ -78,7 +78,7 @@ for (const adapter of adapters) {
 
 		resource.setString("MyNewContent");
 
-		const resource1 = await dest.byPath("/dest/writer/test.js");
+		const resource1 = await dest.byPath("/dest/writer/content/test.js");
 
 		t.is(await resource.getString(), "MyNewContent");
 		t.is(await resource1.getString(), "MyInitialContent");
@@ -88,7 +88,7 @@ for (const adapter of adapters) {
 
 		await dest.write(resource);
 
-		const resource2 = await dest.byPath("/dest/writer/test.js");
+		const resource2 = await dest.byPath("/dest/writer/content/test.js");
 		t.is(await resource.getString(), "MyNewContent");
 		t.is(await resource2.getString(), "MyNewContent");
 	});
@@ -100,32 +100,32 @@ for (const adapter of adapters) {
 		});
 
 		const resource = createResource({
-			path: "/dest/writer/test.js",
+			path: "/dest/writer/path/test.js",
 			string: "MyInitialContent"
 		});
 
 		await dest.write(resource);
 
-		resource.setPath("/dest/writer/test2.js");
+		resource.setPath("/dest/writer/path/test2.js");
 
-		const resourceOldPath = await dest.byPath("/dest/writer/test.js");
-		const resourceNewPath = await dest.byPath("/dest/writer/test2.js");
+		const resourceOldPath = await dest.byPath("/dest/writer/path/test.js");
+		const resourceNewPath = await dest.byPath("/dest/writer/path/test2.js");
 
-		t.is(await resource.getPath(), "/dest/writer/test2.js");
+		t.is(await resource.getPath(), "/dest/writer/path/test2.js");
 		t.truthy(resourceOldPath);
 		t.is(await resourceOldPath.getString(), await resource.getString());
-		t.is(await resourceOldPath.getPath(), "/dest/writer/test.js");
+		t.is(await resourceOldPath.getPath(), "/dest/writer/path/test.js");
 		t.not(resourceNewPath);
 
 		await dest.write(resource);
 
-		const resourceOldPath1 = await dest.byPath("/dest/writer/test.js");
-		const resourceNewPath1 = await dest.byPath("/dest/writer/test2.js");
+		const resourceOldPath1 = await dest.byPath("/dest/writer/path/test.js");
+		const resourceNewPath1 = await dest.byPath("/dest/writer/path/test2.js");
 
-		t.is(await resource.getPath(), "/dest/writer/test2.js");
+		t.is(await resource.getPath(), "/dest/writer/path/test2.js");
 		t.truthy(resourceNewPath1);
 		t.is(await resourceNewPath1.getString(), await resource.getString());
-		t.is(await resourceNewPath1.getPath(), "/dest/writer/test2.js");
+		t.is(await resourceNewPath1.getPath(), "/dest/writer/path/test2.js");
 		t.not(resourceOldPath1);
 	});
 

--- a/test/lib/resources.js
+++ b/test/lib/resources.js
@@ -129,6 +129,22 @@ for (const adapter of adapters) {
 		t.not(resourceOldPath1);
 	});
 
+	test(adapter + ": Create resource with mismatch paths", async (t) => {
+		t.pass(2);
+		const dest = await getAdapter({
+			fsBasePath: "./test/tmp/writer/",
+			virBasePath: "/dest2/writer/"
+		});
+
+		const resource = createResource({
+			path: "/dest2/tmp/test.js",
+			string: "MyContent"
+		});
+
+		const error = await t.throwsAsync(dest.write(resource));
+		t.is(error.message, "The path of the resource does not starts with the virBasePath of the adapter");
+	});
+
 	test(adapter + ": Filter resources", async (t) => {
 		const source = createAdapter({
 			fsBasePath: "./test/fixtures/application.a/webapp",

--- a/test/lib/resources.js
+++ b/test/lib/resources.js
@@ -129,7 +129,7 @@ for (const adapter of adapters) {
 		t.not(resourceOldPath1);
 	});
 
-	test(adapter + ": Create resource with mismatch paths", async (t) => {
+	test(adapter + ": Create a resource with a path not starting with path configured in the adapter", async (t) => {
 		t.pass(2);
 		const dest = await getAdapter({
 			fsBasePath: "./test/tmp/writer/",
@@ -142,7 +142,8 @@ for (const adapter of adapters) {
 		});
 
 		const error = await t.throwsAsync(dest.write(resource));
-		t.is(error.message, "The path of the resource does not starts with the virBasePath of the adapter");
+		t.is(error.message, "The path of the resource '/dest2/tmp/test.js' does not starts with the configured " +
+			"virtual base path of the adapter '/dest2/writer/'");
 	});
 
 	test(adapter + ": Filter resources", async (t) => {


### PR DESCRIPTION
Follow-up of https://github.com/SAP/ui5-fs/pull/448

Only perform the write operation when the path of the resource starts with the configured virtual base path of the respective adapter.