### PR TITLE
[BREAKING] Reader collections: Throw for missing parameters

### DIFF
--- a/lib/DuplexCollection.js
+++ b/lib/DuplexCollection.js
@@ -21,6 +21,12 @@ class DuplexCollection extends AbstractReaderWriter {
 	 */
 	constructor({reader, writer, name = ""}) {
 		super(name);
+		if (!reader) {
+			throw new Error(`Cannot create DuplexCollection ${this._name}: No reader provided`);
+		}
+		if (!writer) {
+			throw new Error(`Cannot create DuplexCollection ${this._name}: No writer provided`);
+		}
 		this._reader = reader;
 		this._writer = writer;
 

--- a/lib/ReaderCollection.js
+++ b/lib/ReaderCollection.js
@@ -18,6 +18,9 @@ class ReaderCollection extends AbstractReader {
 	 */
 	constructor({name, readers}) {
 		super(name);
+		if (!readers.length || readers.includes(undefined)) {
+			throw new Error(`Cannot create ReaderCollection ${this._name}: Provided list of readers is empty`);
+		}
 		this._readers = readers;
 	}
 

--- a/lib/ReaderCollectionPrioritized.js
+++ b/lib/ReaderCollectionPrioritized.js
@@ -19,6 +19,10 @@ class ReaderCollectionPrioritized extends AbstractReader {
 	 */
 	constructor({readers, name}) {
 		super(name);
+		if (!readers.length || readers.includes(undefined)) {
+			throw new Error(
+				`Cannot create ReaderCollectionPrioritized ${this._name}: Provided list of readers is empty`);
+		}
 		this._readers = readers;
 	}
 

--- a/lib/WriterCollection.js
+++ b/lib/WriterCollection.js
@@ -32,11 +32,11 @@ class WriterCollection extends AbstractReaderWriter {
 		super(name);
 
 		if (!writerMapping) {
-			throw new Error("Missing parameter 'writerMapping'");
+			throw new Error(`Cannot create WriterCollection ${this._name}: Missing parameter 'writerMapping'`);
 		}
 		const basePaths = Object.keys(writerMapping);
 		if (!basePaths.length) {
-			throw new Error("Empty parameter 'writerMapping'");
+			throw new Error(`Cannot create WriterCollection ${this._name}: Empty parameter 'writerMapping'`);
 		}
 
 		// Create a regular expression (which is greedy by nature) from all paths to easily

--- a/test/lib/DuplexCollection.js
+++ b/test/lib/DuplexCollection.js
@@ -196,6 +196,7 @@ test("DuplexCollection: _write successful", async (t) => {
 	});
 	const duplexCollection = new DuplexCollection({
 		name: "myCollection",
+		reader: {},
 		writer: {
 			write: sinon.stub().returns(Promise.resolve())
 		}
@@ -203,4 +204,26 @@ test("DuplexCollection: _write successful", async (t) => {
 	await duplexCollection._write(resource);
 
 	t.pass("write on writer called");
+});
+
+test("DuplexCollection: Throws for empty reader", (t) => {
+	t.throws(() => {
+		new DuplexCollection({
+			name: "myReader",
+			writer: {}
+		});
+	}, {
+		message: "Cannot create DuplexCollection myReader: No reader provided"
+	});
+});
+
+test("DuplexCollection: Throws for empty writer", (t) => {
+	t.throws(() => {
+		new DuplexCollection({
+			name: "myReader",
+			reader: {}
+		});
+	}, {
+		message: "Cannot create DuplexCollection myReader: No writer provided"
+	});
 });

--- a/test/lib/ReaderCollectionPrioritized.js
+++ b/test/lib/ReaderCollectionPrioritized.js
@@ -1,32 +1,30 @@
 import test from "ava";
 import sinon from "sinon";
-import ReaderCollection from "../../lib/ReaderCollection.js";
+import ReaderCollectionPrioritized from "../../lib/ReaderCollectionPrioritized.js";
 import Resource from "../../lib/Resource.js";
 
-test("ReaderCollection: constructor", (t) => {
-	const readerCollection = new ReaderCollection({
+test("ReaderCollectionPrioritized: constructor", (t) => {
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [{}, {}, {}]
 	});
 
-	t.is(readerCollection.getName(), "myReader", "correct name assigned");
-	t.deepEqual(readerCollection._readers, [{}, {}, {}], "correct readers assigned");
+	t.is(readerCollectionPrioritized.getName(), "myReader", "correct name assigned");
+	t.deepEqual(readerCollectionPrioritized._readers, [{}, {}, {}], "correct readers assigned");
 });
 
-test("ReaderCollection: _byGlob w/o finding a resource", async (t) => {
-	t.plan(4);
-
+test("ReaderCollectionPrioritized: _byGlob w/o finding a resource", async (t) => {
 	const abstractReader = {
 		_byGlob: sinon.stub().returns(Promise.resolve([]))
 	};
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [abstractReader]
 	});
-	const resources = await readerCollection._byGlob("anyPattern", {someOption: true}, trace);
+	const resources = await readerCollectionPrioritized._byGlob("anyPattern", {someOption: true}, trace);
 
 	t.true(Array.isArray(resources), "Found resources are returned as an array");
 	t.true(resources.length === 0, "No resources found");
@@ -35,9 +33,7 @@ test("ReaderCollection: _byGlob w/o finding a resource", async (t) => {
 	t.true(trace.collection.called, "Trace.collection called");
 });
 
-test("ReaderCollection: _byGlob with finding a resource", async (t) => {
-	t.plan(6);
-
+test("ReaderCollectionPrioritized: _byGlob with finding a resource", async (t) => {
 	const resource = new Resource({
 		path: "my/path",
 		buffer: Buffer.from("content")
@@ -48,12 +44,12 @@ test("ReaderCollection: _byGlob with finding a resource", async (t) => {
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [abstractReader]
 	});
 
-	const resources = await readerCollection._byGlob("anyPattern", {someOption: true}, trace);
+	const resources = await readerCollectionPrioritized._byGlob("anyPattern", {someOption: true}, trace);
 	const resourceContent = await resources[0].getString();
 
 	t.true(Array.isArray(resources), "Found resources are returned as an array");
@@ -65,9 +61,7 @@ test("ReaderCollection: _byGlob with finding a resource", async (t) => {
 	t.is(resourceContent, "content", "Resource has expected content");
 });
 
-test("ReaderCollection: _byPath with reader finding a resource", async (t) => {
-	t.plan(5);
-
+test("ReaderCollectionPrioritized: _byPath with reader finding a resource", async (t) => {
 	const resource = new Resource({
 		path: "my/path",
 		buffer: Buffer.from("content")
@@ -79,25 +73,22 @@ test("ReaderCollection: _byPath with reader finding a resource", async (t) => {
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [abstractReader]
 	});
 
-	const readResource = await readerCollection._byPath("anyVirtualPath", {someOption: true}, trace);
+	const readResource = await readerCollectionPrioritized._byPath("anyVirtualPath", {someOption: true}, trace);
 	const readResourceContent = await resource.getString();
 
 	t.true(abstractReader._byPath.calledWithExactly("anyVirtualPath", {someOption: true}, trace),
 		"Delegated globbing task correctly to readers");
-	t.true(trace.collection.called, "Trace.collection called");
 	t.true(pushCollectionSpy.called, "pushCollection called on resource");
 	t.is(readResource.getPath(), "my/path", "Resource has expected path");
 	t.is(readResourceContent, "content", "Resource has expected content");
 });
 
-test("ReaderCollection: _byPath with two readers both finding no resource", async (t) => {
-	t.plan(4);
-
+test("ReaderCollectionPrioritized: _byPath with two readers both finding no resource", async (t) => {
 	const abstractReaderOne = {
 		_byPath: sinon.stub().returns(Promise.resolve())
 	};
@@ -107,33 +98,32 @@ test("ReaderCollection: _byPath with two readers both finding no resource", asyn
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [abstractReaderOne, abstractReaderTwo]
 	});
 
-	const resource = await readerCollection._byPath("anyVirtualPath", {someOption: true}, trace);
+	const resource = await readerCollectionPrioritized._byPath("anyVirtualPath", {someOption: true}, trace);
 
 	t.falsy(resource, "No resource found");
 	t.true(abstractReaderOne._byPath.calledWithExactly("anyVirtualPath", {someOption: true}, trace),
 		"Delegated globbing task correctly to reader one");
 	t.true(abstractReaderTwo._byPath.calledWithExactly("anyVirtualPath", {someOption: true}, trace),
 		"Delegated globbing task correctly to reader two");
-	t.true(trace.collection.calledTwice, "Trace.collection called");
 });
 
-test("ReaderCollection: Throws for empty readers array", (t) => {
+test("ReaderCollectionPrioritized: Throws for empty readers array", (t) => {
 	t.throws(() => {
-		new ReaderCollection({
+		new ReaderCollectionPrioritized({
 			name: "myReader",
 			readers: []
 		});
 	}, {
-		message: "Cannot create ReaderCollection myReader: Provided list of readers is empty"
+		message: "Cannot create ReaderCollectionPrioritized myReader: Provided list of readers is empty"
 	});
 
 	t.throws(() => {
-		new ReaderCollection({
+		new ReaderCollectionPrioritized({
 			name: "myReader",
 
 			// This can happen for example in custom tasks where the dependencies reader
@@ -141,6 +131,6 @@ test("ReaderCollection: Throws for empty readers array", (t) => {
 			readers: [undefined]
 		});
 	}, {
-		message: "Cannot create ReaderCollection myReader: Provided list of readers is empty"
+		message: "Cannot create ReaderCollectionPrioritized myReader: Provided list of readers is empty"
 	});
 });

--- a/test/lib/WriterCollection.js
+++ b/test/lib/WriterCollection.js
@@ -37,7 +37,8 @@ test("Constructor: Throws for missing path mapping", (t) => {
 			name: "myCollection"
 		});
 	});
-	t.is(err.message, "Missing parameter 'writerMapping'", "Threw with expected error message");
+	t.is(err.message, "Cannot create WriterCollection myCollection: Missing parameter 'writerMapping'",
+		"Threw with expected error message");
 });
 
 test("Constructor: Throws for empty path mapping", (t) => {
@@ -47,7 +48,8 @@ test("Constructor: Throws for empty path mapping", (t) => {
 			writerMapping: {}
 		});
 	});
-	t.is(err.message, "Empty parameter 'writerMapping'", "Threw with expected error message");
+	t.is(err.message, "Cannot create WriterCollection myCollection: Empty parameter 'writerMapping'",
+		"Threw with expected error message");
 });
 
 test("Constructor: Throws for empty path", (t) => {


### PR DESCRIPTION
Also add dedicated tests for ReaderCollectionPrioritized (99% copy of
ReaderCollection tests)

BREAKING CHANGE:
In the past, some reader collections allowed to be instantiated without
any readers. With this change, that is no longer possible.