### PR TITLE
[INTERNAL] Reader Collections: Allow for empty readers

### DIFF
--- a/lib/DuplexCollection.js
+++ b/lib/DuplexCollection.js
@@ -21,6 +21,14 @@ class DuplexCollection extends AbstractReaderWriter {
 	 */
 	constructor({reader, writer, name = ""}) {
 		super(name);
+
+		if (!reader) {
+			throw new Error(`Cannot create DuplexCollection ${this._name}: No reader provided`);
+		}
+		if (!writer) {
+			throw new Error(`Cannot create DuplexCollection ${this._name}: No writer provided`);
+		}
+
 		this._reader = reader;
 		this._writer = writer;
 
@@ -73,7 +81,8 @@ class DuplexCollection extends AbstractReaderWriter {
 	 * @param {string} virPath Virtual path
 	 * @param {object} options Options
 	 * @param {@ui5/fs/tracing.Trace} trace Trace instance
-	 * @returns {Promise<@ui5/fs/Resource>} Promise resolving to a single resource
+	 * @returns {Promise<@ui5/fs/Resource|null>}
+	 *   Promise resolving to a single resource or <code>null</code> if no resource is found
 	 */
 	_byPath(virPath, options, trace) {
 		return this._combo._byPath(virPath, options, trace);

--- a/lib/ReaderCollection.js
+++ b/lib/ReaderCollection.js
@@ -20,10 +20,12 @@ class ReaderCollection extends AbstractReader {
 	 */
 	constructor({name, readers}) {
 		super(name);
-		if (!readers.length || readers.includes(undefined)) {
+
+		// Remove any undefined (empty) readers from array
+		this._readers = readers.filter(($) => $);
+		if (!this._readers.length) {
 			this._emptyCollection = true;
 		}
-		this._readers = readers;
 	}
 
 	/**

--- a/lib/ReaderCollection.js
+++ b/lib/ReaderCollection.js
@@ -14,10 +14,15 @@ class ReaderCollection extends AbstractReader {
 	 *
 	 * @param {object} parameters Parameters
 	 * @param {string} parameters.name The collection name
-	 * @param {@ui5/fs/AbstractReader[]} parameters.readers List of resource readers (all tried in parallel)
+	 * @param {@ui5/fs/AbstractReader[]} [parameters.readers]
+	 *   List of resource readers (all tried in parallel).
+	 *   If none are provided, the collection will never return any results.
 	 */
 	constructor({name, readers}) {
 		super(name);
+		if (!readers.length || readers.includes(undefined)) {
+			this._emptyCollection = true;
+		}
 		this._readers = readers;
 	}
 
@@ -32,6 +37,9 @@ class ReaderCollection extends AbstractReader {
 	 * @returns {Promise<@ui5/fs/Resource[]>} Promise resolving to list of resources
 	 */
 	_byGlob(pattern, options, trace) {
+		if (this._emptyCollection) {
+			return Promise.resolve([]);
+		}
 		return Promise.all(this._readers.map(function(resourceLocator) {
 			return resourceLocator._byGlob(pattern, options, trace);
 		})).then((result) => {
@@ -47,17 +55,16 @@ class ReaderCollection extends AbstractReader {
 	 * @param {string} virPath Virtual path
 	 * @param {object} options Options
 	 * @param {@ui5/fs/tracing.Trace} trace Trace instance
-	 * @returns {Promise<@ui5/fs/Resource>} Promise resolving to a single resource
+	 * @returns {Promise<@ui5/fs/Resource|null>}
+	 *   Promise resolving to a single resource or <code>null</code> if no resource is found
 	 */
 	_byPath(virPath, options, trace) {
+		if (this._emptyCollection) {
+			return Promise.resolve(null);
+		}
 		const that = this;
 		const resourceLocatorCount = this._readers.length;
 		let resolveCount = 0;
-
-		if (this._readers.length === 0) {
-			// Promise.race doesn't resolve for empty arrays
-			return Promise.resolve();
-		}
 
 		/* Promise.race to cover the following (self defined) requirement:
 			Deliver files that can be found fast at the cost of slower response times for files that cannot be found.

--- a/lib/ReaderCollection.js
+++ b/lib/ReaderCollection.js
@@ -61,6 +61,7 @@ class ReaderCollection extends AbstractReader {
 
 		if (resourceLocatorCount === 0) {
 			// Short-circuit if there are no readers (Promise.race does not settle for empty arrays)
+			trace.collection(that._name);
 			return Promise.resolve(null);
 		}
 

--- a/lib/ReaderCollection.js
+++ b/lib/ReaderCollection.js
@@ -23,9 +23,6 @@ class ReaderCollection extends AbstractReader {
 
 		// Remove any undefined (empty) readers from array
 		this._readers = readers.filter(($) => $);
-		if (!this._readers.length) {
-			this._emptyCollection = true;
-		}
 	}
 
 	/**
@@ -39,9 +36,6 @@ class ReaderCollection extends AbstractReader {
 	 * @returns {Promise<@ui5/fs/Resource[]>} Promise resolving to list of resources
 	 */
 	_byGlob(pattern, options, trace) {
-		if (this._emptyCollection) {
-			return Promise.resolve([]);
-		}
 		return Promise.all(this._readers.map(function(resourceLocator) {
 			return resourceLocator._byGlob(pattern, options, trace);
 		})).then((result) => {
@@ -61,16 +55,16 @@ class ReaderCollection extends AbstractReader {
 	 *   Promise resolving to a single resource or <code>null</code> if no resource is found
 	 */
 	_byPath(virPath, options, trace) {
-		if (this._emptyCollection) {
-			return Promise.resolve(null);
-		}
 		const that = this;
 		const resourceLocatorCount = this._readers.length;
 		let resolveCount = 0;
 
-		/* Promise.race to cover the following (self defined) requirement:
-			Deliver files that can be found fast at the cost of slower response times for files that cannot be found.
-		*/
+		if (resourceLocatorCount === 0) {
+			// Short-circuit if there are no readers (Promise.race does not settle for empty arrays)
+			return Promise.resolve(null);
+		}
+
+		// Using Promise.race to deliver files that can be found as fast as possible
 		return Promise.race(this._readers.map(function(resourceLocator) {
 			return resourceLocator._byPath(virPath, options, trace).then(function(resource) {
 				return new Promise(function(resolve, reject) {

--- a/lib/ReaderCollectionPrioritized.js
+++ b/lib/ReaderCollectionPrioritized.js
@@ -20,10 +20,12 @@ class ReaderCollectionPrioritized extends AbstractReader {
 	 */
 	constructor({readers, name}) {
 		super(name);
-		if (!readers.length || readers.includes(undefined)) {
+
+		// Remove any undefined (empty) readers from array
+		this._readers = readers.filter(($) => $);
+		if (!this._readers.length) {
 			this._emptyCollection = true;
 		}
-		this._readers = readers;
 	}
 
 	/**

--- a/lib/ReaderCollectionPrioritized.js
+++ b/lib/ReaderCollectionPrioritized.js
@@ -14,11 +14,15 @@ class ReaderCollectionPrioritized extends AbstractReader {
 	 *
 	 * @param {object} parameters
 	 * @param {string} parameters.name The collection name
-	 * @param {@ui5/fs/AbstractReader[]} parameters.readers Prioritized list of resource readers
-	 * 																(first is tried first)
+	 * @param {@ui5/fs/AbstractReader[]} [parameters.readers]
+	 *   Prioritized list of resource readers (tried in the order provided).
+	 *   If none are provided, the collection will never return any results.
 	 */
 	constructor({readers, name}) {
 		super(name);
+		if (!readers.length || readers.includes(undefined)) {
+			this._emptyCollection = true;
+		}
 		this._readers = readers;
 	}
 
@@ -33,6 +37,9 @@ class ReaderCollectionPrioritized extends AbstractReader {
 	 * @returns {Promise<@ui5/fs/Resource[]>} Promise resolving to list of resources
 	 */
 	_byGlob(pattern, options, trace) {
+		if (this._emptyCollection) {
+			return Promise.resolve([]);
+		}
 		return Promise.all(this._readers.map(function(resourceLocator) {
 			return resourceLocator._byGlob(pattern, options, trace);
 		})).then((result) => {
@@ -62,9 +69,13 @@ class ReaderCollectionPrioritized extends AbstractReader {
 	 * @param {string} virPath Virtual path
 	 * @param {object} options Options
 	 * @param {@ui5/fs/tracing.Trace} trace Trace instance
-	 * @returns {Promise<@ui5/fs/Resource>} Promise resolving to a single resource
+	 * @returns {Promise<@ui5/fs/Resource|null>}
+	 *   Promise resolving to a single resource or <code>null</code> if no resource is found
 	 */
 	_byPath(virPath, options, trace) {
+		if (this._emptyCollection) {
+			return Promise.resolve(null);
+		}
 		const that = this;
 		const byPath = (i) => {
 			if (i > this._readers.length - 1) {

--- a/lib/ReaderCollectionPrioritized.js
+++ b/lib/ReaderCollectionPrioritized.js
@@ -23,9 +23,6 @@ class ReaderCollectionPrioritized extends AbstractReader {
 
 		// Remove any undefined (empty) readers from array
 		this._readers = readers.filter(($) => $);
-		if (!this._readers.length) {
-			this._emptyCollection = true;
-		}
 	}
 
 	/**
@@ -39,9 +36,6 @@ class ReaderCollectionPrioritized extends AbstractReader {
 	 * @returns {Promise<@ui5/fs/Resource[]>} Promise resolving to list of resources
 	 */
 	_byGlob(pattern, options, trace) {
-		if (this._emptyCollection) {
-			return Promise.resolve([]);
-		}
 		return Promise.all(this._readers.map(function(resourceLocator) {
 			return resourceLocator._byGlob(pattern, options, trace);
 		})).then((result) => {
@@ -75,9 +69,6 @@ class ReaderCollectionPrioritized extends AbstractReader {
 	 *   Promise resolving to a single resource or <code>null</code> if no resource is found
 	 */
 	_byPath(virPath, options, trace) {
-		if (this._emptyCollection) {
-			return Promise.resolve(null);
-		}
 		const that = this;
 		const byPath = (i) => {
 			if (i > this._readers.length - 1) {

--- a/lib/WriterCollection.js
+++ b/lib/WriterCollection.js
@@ -32,11 +32,11 @@ class WriterCollection extends AbstractReaderWriter {
 		super(name);
 
 		if (!writerMapping) {
-			throw new Error("Missing parameter 'writerMapping'");
+			throw new Error(`Cannot create WriterCollection ${this._name}: Missing parameter 'writerMapping'`);
 		}
 		const basePaths = Object.keys(writerMapping);
 		if (!basePaths.length) {
-			throw new Error("Empty parameter 'writerMapping'");
+			throw new Error(`Cannot create WriterCollection ${this._name}: Empty parameter 'writerMapping'`);
 		}
 
 		// Create a regular expression (which is greedy by nature) from all paths to easily

--- a/test/lib/DuplexCollection.js
+++ b/test/lib/DuplexCollection.js
@@ -196,6 +196,7 @@ test("DuplexCollection: _write successful", async (t) => {
 	});
 	const duplexCollection = new DuplexCollection({
 		name: "myCollection",
+		reader: {},
 		writer: {
 			write: sinon.stub().returns(Promise.resolve())
 		}
@@ -203,4 +204,26 @@ test("DuplexCollection: _write successful", async (t) => {
 	await duplexCollection._write(resource);
 
 	t.pass("write on writer called");
+});
+
+test("DuplexCollection: Throws for empty reader", (t) => {
+	t.throws(() => {
+		new DuplexCollection({
+			name: "myReader",
+			writer: {}
+		});
+	}, {
+		message: "Cannot create DuplexCollection myReader: No reader provided"
+	});
+});
+
+test("DuplexCollection: Throws for empty writer", (t) => {
+	t.throws(() => {
+		new DuplexCollection({
+			name: "myReader",
+			reader: {}
+		});
+	}, {
+		message: "Cannot create DuplexCollection myReader: No writer provided"
+	});
 });

--- a/test/lib/ReaderCollectionPrioritized.js
+++ b/test/lib/ReaderCollectionPrioritized.js
@@ -1,32 +1,30 @@
 import test from "ava";
 import sinon from "sinon";
-import ReaderCollection from "../../lib/ReaderCollection.js";
+import ReaderCollectionPrioritized from "../../lib/ReaderCollectionPrioritized.js";
 import Resource from "../../lib/Resource.js";
 
-test("ReaderCollection: constructor", (t) => {
-	const readerCollection = new ReaderCollection({
+test("ReaderCollectionPrioritized: constructor", (t) => {
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [{}, {}, {}]
 	});
 
-	t.is(readerCollection.getName(), "myReader", "correct name assigned");
-	t.deepEqual(readerCollection._readers, [{}, {}, {}], "correct readers assigned");
+	t.is(readerCollectionPrioritized.getName(), "myReader", "correct name assigned");
+	t.deepEqual(readerCollectionPrioritized._readers, [{}, {}, {}], "correct readers assigned");
 });
 
-test("ReaderCollection: _byGlob w/o finding a resource", async (t) => {
-	t.plan(4);
-
+test("ReaderCollectionPrioritized: _byGlob w/o finding a resource", async (t) => {
 	const abstractReader = {
 		_byGlob: sinon.stub().returns(Promise.resolve([]))
 	};
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [abstractReader]
 	});
-	const resources = await readerCollection._byGlob("anyPattern", {someOption: true}, trace);
+	const resources = await readerCollectionPrioritized._byGlob("anyPattern", {someOption: true}, trace);
 
 	t.true(Array.isArray(resources), "Found resources are returned as an array");
 	t.true(resources.length === 0, "No resources found");
@@ -35,9 +33,7 @@ test("ReaderCollection: _byGlob w/o finding a resource", async (t) => {
 	t.true(trace.collection.called, "Trace.collection called");
 });
 
-test("ReaderCollection: _byGlob with finding a resource", async (t) => {
-	t.plan(6);
-
+test("ReaderCollectionPrioritized: _byGlob with finding a resource", async (t) => {
 	const resource = new Resource({
 		path: "my/path",
 		buffer: Buffer.from("content")
@@ -48,12 +44,12 @@ test("ReaderCollection: _byGlob with finding a resource", async (t) => {
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [abstractReader]
 	});
 
-	const resources = await readerCollection._byGlob("anyPattern", {someOption: true}, trace);
+	const resources = await readerCollectionPrioritized._byGlob("anyPattern", {someOption: true}, trace);
 	const resourceContent = await resources[0].getString();
 
 	t.true(Array.isArray(resources), "Found resources are returned as an array");
@@ -65,9 +61,7 @@ test("ReaderCollection: _byGlob with finding a resource", async (t) => {
 	t.is(resourceContent, "content", "Resource has expected content");
 });
 
-test("ReaderCollection: _byPath with reader finding a resource", async (t) => {
-	t.plan(5);
-
+test("ReaderCollectionPrioritized: _byPath with reader finding a resource", async (t) => {
 	const resource = new Resource({
 		path: "my/path",
 		buffer: Buffer.from("content")
@@ -79,25 +73,22 @@ test("ReaderCollection: _byPath with reader finding a resource", async (t) => {
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [abstractReader]
 	});
 
-	const readResource = await readerCollection._byPath("anyVirtualPath", {someOption: true}, trace);
+	const readResource = await readerCollectionPrioritized._byPath("anyVirtualPath", {someOption: true}, trace);
 	const readResourceContent = await resource.getString();
 
 	t.true(abstractReader._byPath.calledWithExactly("anyVirtualPath", {someOption: true}, trace),
 		"Delegated globbing task correctly to readers");
-	t.true(trace.collection.called, "Trace.collection called");
 	t.true(pushCollectionSpy.called, "pushCollection called on resource");
 	t.is(readResource.getPath(), "my/path", "Resource has expected path");
 	t.is(readResourceContent, "content", "Resource has expected content");
 });
 
-test("ReaderCollection: _byPath with two readers both finding no resource", async (t) => {
-	t.plan(4);
-
+test("ReaderCollectionPrioritized: _byPath with two readers both finding no resource", async (t) => {
 	const abstractReaderOne = {
 		_byPath: sinon.stub().returns(Promise.resolve())
 	};
@@ -107,47 +98,46 @@ test("ReaderCollection: _byPath with two readers both finding no resource", asyn
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: [abstractReaderOne, abstractReaderTwo]
 	});
 
-	const resource = await readerCollection._byPath("anyVirtualPath", {someOption: true}, trace);
+	const resource = await readerCollectionPrioritized._byPath("anyVirtualPath", {someOption: true}, trace);
 
 	t.falsy(resource, "No resource found");
 	t.true(abstractReaderOne._byPath.calledWithExactly("anyVirtualPath", {someOption: true}, trace),
 		"Delegated globbing task correctly to reader one");
 	t.true(abstractReaderTwo._byPath.calledWithExactly("anyVirtualPath", {someOption: true}, trace),
 		"Delegated globbing task correctly to reader two");
-	t.true(trace.collection.calledTwice, "Trace.collection called");
 });
 
-test("ReaderCollection: _byPath with empty readers array", async (t) => {
+test("ReaderCollectionPrioritized: _byPath with empty readers array", async (t) => {
 	t.plan(1);
 
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: []
 	});
 
-	const resource = await readerCollection._byPath("anyVirtualPath", {someOption: true}, trace);
+	const resource = await readerCollectionPrioritized._byPath("anyVirtualPath", {someOption: true}, trace);
 	t.is(resource, null, "Promise resolves to null, as no readers got configured");
 });
 
-test("ReaderCollection: _byGlob with empty readers array", async (t) => {
+test("ReaderCollectionPrioritized: _byGlob with empty readers array", async (t) => {
 	t.plan(1);
 
 	const trace = {
 		collection: sinon.spy()
 	};
-	const readerCollection = new ReaderCollection({
+	const readerCollectionPrioritized = new ReaderCollectionPrioritized({
 		name: "myReader",
 		readers: []
 	});
 
-	const resource = await readerCollection.byGlob("anyPattern", {someOption: true}, trace);
+	const resource = await readerCollectionPrioritized.byGlob("anyPattern", {someOption: true}, trace);
 	t.deepEqual(resource, [], "Promise resolves to null, as no readers got configured");
 });

--- a/test/lib/WriterCollection.js
+++ b/test/lib/WriterCollection.js
@@ -37,7 +37,8 @@ test("Constructor: Throws for missing path mapping", (t) => {
 			name: "myCollection"
 		});
 	});
-	t.is(err.message, "Missing parameter 'writerMapping'", "Threw with expected error message");
+	t.is(err.message, "Cannot create WriterCollection myCollection: Missing parameter 'writerMapping'",
+		"Threw with expected error message");
 });
 
 test("Constructor: Throws for empty path mapping", (t) => {
@@ -47,7 +48,8 @@ test("Constructor: Throws for empty path mapping", (t) => {
 			writerMapping: {}
 		});
 	});
-	t.is(err.message, "Empty parameter 'writerMapping'", "Threw with expected error message");
+	t.is(err.message, "Cannot create WriterCollection myCollection: Empty parameter 'writerMapping'",
+		"Threw with expected error message");
 });
 
 test("Constructor: Throws for empty path", (t) => {


### PR DESCRIPTION
If no readers are provided, no error is thrown and no resources are returned.

This behavior was mostly already in place (and relied upon) but never fully specified.

This makes it easy to implement tasks that just want to fetch any available dependencies, even if none are available (for example if the project has no dependencies).

See also https://github.com/SAP/ui5-fs/pull/455 for the opposite approach of dissallowing collections without readers.

Also add tests for ReaderCollectionPrioritized (99% copy of the ReaderCollection tests)