### PR TITLE
[INTERNAL] AbstractAdapter: Correct typo in error message

### DIFF
--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -210,7 +210,7 @@ class AbstractAdapter extends AbstractReaderWriter {
 
 	_write(resource) {
 		if (!resource.getPath().startsWith(this._virBasePath)) {
-			throw new Error(`The path of the resource '${resource.getPath()}' does not starts with ` +
+			throw new Error(`The path of the resource '${resource.getPath()}' does not start with ` +
 				`the configured virtual base path of the adapter '${this._virBasePath}'`);
 		}
 

--- a/test/lib/adapters/AbstractAdapter.js
+++ b/test/lib/adapters/AbstractAdapter.js
@@ -57,6 +57,6 @@ test("Create a resource with a path not starting with path configured in the ada
 
 	const error = t.throws(() => writer._write(resource));
 	t.is(error.message,
-		"The path of the resource '/dest2/tmp/test.js' does not starts with the configured " +
+		"The path of the resource '/dest2/tmp/test.js' does not start with the configured " +
 			"virtual base path of the adapter '/dest2/writer/'");
 });

--- a/test/lib/resources.js
+++ b/test/lib/resources.js
@@ -142,7 +142,7 @@ for (const adapter of adapters) {
 		});
 
 		const error = await t.throwsAsync(dest.write(resource));
-		t.is(error.message, "The path of the resource '/dest2/tmp/test.js' does not starts with the configured " +
+		t.is(error.message, "The path of the resource '/dest2/tmp/test.js' does not start with the configured " +
 			"virtual base path of the adapter '/dest2/writer/'");
 	});
 


### PR DESCRIPTION
Sadly a typo was introduced in the newly created error message. Therefore, fixing the typo with this PR.

Follow-Up of: https://github.com/SAP/ui5-fs/pull/453