### PR TITLE
[INTERNAL] Refactor log-calls

### DIFF
--- a/lib/adapters/FileSystem.js
+++ b/lib/adapters/FileSystem.js
@@ -227,9 +227,9 @@ class FileSystem extends AbstractAdapter {
 			// fs.copyFile can be used when the resource is from FS and hasn't been modified
 			// In addition, nothing needs to be done when src === dest
 			if (resourceSource.fsPath === fsPath) {
-				log.silly("Skip writing to %s (Resource hasn't been modified)", fsPath);
+				log.silly(`Skip writing to ${fsPath} (Resource hasn't been modified)`);
 			} else {
-				log.silly("Copying resource from %s to %s", resourceSource.fsPath, fsPath);
+				log.silly(`Copying resource from ${resourceSource.fsPath} to ${fsPath}`);
 				await copyFile(resourceSource.fsPath, fsPath);
 				if (readOnly) {
 					await chmod(fsPath, READ_ONLY_MODE);
@@ -238,7 +238,7 @@ class FileSystem extends AbstractAdapter {
 			return;
 		}
 
-		log.silly("Writing to %s", fsPath);
+		log.silly(`Writing to ${fsPath}`);
 
 		return new Promise((resolve, reject) => {
 			let contentStream;

--- a/lib/adapters/Memory.js
+++ b/lib/adapters/Memory.js
@@ -124,7 +124,7 @@ class Memory extends AbstractAdapter {
 		resource = await this._migrateResource(resource);
 		super._write(resource);
 		const relPath = resource.getPath().substr(this._virBasePath.length);
-		log.silly("Writing to virtual path %s", resource.getPath());
+		log.silly(`Writing to virtual path ${resource.getPath()}`);
 		this._virFiles[relPath] = await resource.clone();
 
 		// Add virtual directories for all path segments of the written resource


### PR DESCRIPTION
Use template literals wherever possible.

This is in prepration for @ui5/logger changes as per
https://github.com/SAP/ui5-logger/pull/353