### PR TITLE
[INTERNAL] Resource#clone: Omit project association

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -325,10 +325,6 @@ class Resource {
 			options.buffer = this._buffer;
 		}
 
-		if (this.__project) {
-			options.project = this.__project;
-		}
-
 		return options;
 	}
 

--- a/lib/adapters/Memory.js
+++ b/lib/adapters/Memory.js
@@ -40,9 +40,20 @@ class Memory extends AbstractAdapter {
 		const matchedPaths = micromatch(resourcePaths, patterns, {
 			dot: true
 		});
-		return Promise.all(matchedPaths.map((virPath) => {
-			return resourceMap[virPath] && resourceMap[virPath].clone();
+		return await Promise.all(matchedPaths.map((virPath) => {
+			const resource = resourceMap[virPath];
+			if (resource) {
+				return this._cloneResource(resource);
+			}
 		}));
+	}
+
+	async _cloneResource(resource) {
+		const clonedResource = await resource.clone();
+		if (this._project) {
+			clonedResource.setProject(this._project);
+		}
+		return clonedResource;
 	}
 
 	/**
@@ -109,7 +120,7 @@ class Memory extends AbstractAdapter {
 		if (!resource || (options.nodir && resource.getStatInfo().isDirectory())) {
 			return null;
 		} else {
-			return await resource.clone();
+			return await this._cloneResource(resource);
 		}
 	}
 

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -341,16 +341,11 @@ test("Resource: clone resource with source", async (t) => {
 	t.deepEqual(clonedResource2.getSource(), resource.getSource());
 });
 
-test("Resource: clone resource with project", async (t) => {
+test("Resource: clone resource with project removes project", async (t) => {
 	t.plan(2);
 
 	const myProject = {
 		name: "my project"
-	};
-
-	const resourceOptions = {
-		path: "my/path/to/resource",
-		project: myProject
 	};
 
 	const resource = new Resource({
@@ -362,8 +357,7 @@ test("Resource: clone resource with project", async (t) => {
 	t.pass("Resource cloned");
 
 	const clonedResourceProject = await clonedResource.getProject();
-	t.is(clonedResourceProject, resourceOptions.project, "Cloned resource should have same " +
-		"project reference as the original resource");
+	t.falsy(clonedResourceProject, "Cloned resource should not have a project");
 });
 
 test("Resource: create resource with modified source", (t) => {


### PR DESCRIPTION
When cloning a Resource, the new Resource instance should not be associated with any project. This allows for use cases where a resource is copied from one project to another.

The problematic behavior was introduced with https://github.com/SAP/ui5-fs/pull/448 and motivated by the need of the memory adapter to clone resources while keeping the project association.

However, since memory adapters are always assigned a project, they can easily just assign that project to the cloned resource. This has been implemented in this PR.