### PR TITLE
[FEATURE] Resource: Add isModified method

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -13,6 +13,20 @@ const fnFalse = () => false;
  * @alias @ui5/fs/Resource
  */
 class Resource {
+	#project;
+	#buffer;
+	#buffering;
+	#collections;
+	#contentDrained;
+	#createStream;
+	#name;
+	#path;
+	#sourceMetadata;
+	#statInfo;
+	#stream;
+	#streamDrained;
+	#isModified;
+
 	/**
 	* Function for dynamic creation of content streams
 	*
@@ -52,20 +66,20 @@ class Resource {
 				"Buffer, string, stream or createStream");
 		}
 
-		this._path = path;
-		this._name = Resource._getNameFromPath(path);
+		this.#path = path;
+		this.#name = Resource._getNameFromPath(path);
 
-		this._sourceMetadata = sourceMetadata;
-		if (this._sourceMetadata) {
+		this.#sourceMetadata = sourceMetadata;
+		if (this.#sourceMetadata) {
 			// This flag indicates whether a resource has changed from its original source.
 			// resource.isModified() is not sufficient, since it only reflects the modification state of the
 			// current instance.
 			// Since the sourceMetadata object is inherited to clones, it is the only correct indicator
-			this._sourceMetadata.contentModified = this._sourceMetadata.contentModified || false;
+			this.#sourceMetadata.contentModified = this.#sourceMetadata.contentModified || false;
 		}
-		this.__project = project; // Two underscores since "_project" was widely used in UI5 Tooling 2.0
+		this.#project = project;
 
-		this._statInfo = statInfo || { // TODO
+		this.#statInfo = statInfo || { // TODO
 			isFile: fnTrue,
 			isDirectory: fnFalse,
 			isBlockDevice: fnFalse,
@@ -84,9 +98,9 @@ class Resource {
 		};
 
 		if (createStream) {
-			this._createStream = createStream;
+			this.#createStream = createStream;
 		} else if (stream) {
-			this._stream = stream;
+			this.#stream = stream;
 		} else if (buffer) {
 			this.setBuffer(buffer);
 		} else if (typeof string === "string" || string instanceof String) {
@@ -94,9 +108,9 @@ class Resource {
 		}
 
 		// Tracing:
-		this._collections = [];
+		this.#collections = [];
 
-		this._isModified = false;
+		this.#isModified = false;
 	}
 
 	static _getNameFromPath(virPath) {
@@ -110,17 +124,17 @@ class Resource {
 	 * @returns {Promise<Buffer>} Promise resolving with a buffer of the resource content.
 	 */
 	async getBuffer() {
-		if (this._contentDrained) {
-			throw new Error(`Content of Resource ${this._path} has been drained. ` +
+		if (this.#contentDrained) {
+			throw new Error(`Content of Resource ${this.#path} has been drained. ` +
 				"This might be caused by requesting resource content after a content stream has been " +
 				"requested and no new content (e.g. a new stream) has been set.");
 		}
-		if (this._buffer) {
-			return this._buffer;
-		} else if (this._createStream || this._stream) {
-			return this._getBufferFromStream();
+		if (this.#buffer) {
+			return this.#buffer;
+		} else if (this.#createStream || this.#stream) {
+			return this.#getBufferFromStream();
 		} else {
-			throw new Error(`Resource ${this._path} has no content`);
+			throw new Error(`Resource ${this.#path} has no content`);
 		}
 	}
 
@@ -131,22 +145,22 @@ class Resource {
 	 * @param {Buffer} buffer Buffer instance
 	 */
 	setBuffer(buffer) {
-		if (this._sourceMetadata) {
-			this._sourceMetadata.contentModified = true;
+		if (this.#sourceMetadata) {
+			this.#sourceMetadata.contentModified = true;
 		}
-		this._isModified = true;
-		this._setBuffer(buffer);
+		this.#isModified = true;
+		this.#setBuffer(buffer);
 	}
 
-	_setBuffer(buffer) {
-		this._createStream = null;
-		// if (this._stream) { // TODO this may cause strange issues
-		// 	this._stream.destroy();
+	#setBuffer(buffer) {
+		this.#createStream = null;
+		// if (this.#stream) { // TODO this may cause strange issues
+		// 	this.#stream.destroy();
 		// }
-		this._stream = null;
-		this._buffer = buffer;
-		this._contentDrained = false;
-		this._streamDrained = false;
+		this.#stream = null;
+		this.#buffer = buffer;
+		this.#contentDrained = false;
+		this.#streamDrained = false;
 	}
 
 	/**
@@ -156,8 +170,8 @@ class Resource {
 	 * @returns {Promise<string>} Promise resolving with the resource content.
 	 */
 	getString() {
-		if (this._contentDrained) {
-			return Promise.reject(new Error(`Content of Resource ${this._path} has been drained. ` +
+		if (this.#contentDrained) {
+			return Promise.reject(new Error(`Content of Resource ${this.#path} has been drained. ` +
 				"This might be caused by requesting resource content after a content stream has been " +
 				"requested and no new content (e.g. a new stream) has been set."));
 		}
@@ -186,21 +200,21 @@ class Resource {
 	 * @returns {stream.Readable} Readable stream for the resource content.
 	 */
 	getStream() {
-		if (this._contentDrained) {
-			throw new Error(`Content of Resource ${this._path} has been drained. ` +
+		if (this.#contentDrained) {
+			throw new Error(`Content of Resource ${this.#path} has been drained. ` +
 				"This might be caused by requesting resource content after a content stream has been " +
 				"requested and no new content (e.g. a new stream) has been set.");
 		}
 		let contentStream;
-		if (this._buffer) {
+		if (this.#buffer) {
 			const bufferStream = new stream.PassThrough();
-			bufferStream.end(this._buffer);
+			bufferStream.end(this.#buffer);
 			contentStream = bufferStream;
-		} else if (this._createStream || this._stream) {
-			contentStream = this._getStream();
+		} else if (this.#createStream || this.#stream) {
+			contentStream = this.#getStream();
 		}
 		if (!contentStream) {
-			throw new Error(`Resource ${this._path} has no content`);
+			throw new Error(`Resource ${this.#path} has no content`);
 		}
 		// If a stream instance is being returned, it will typically get drained be the consumer.
 		// In that case, further content access will result in a "Content stream has been drained" error.
@@ -210,7 +224,7 @@ class Resource {
 		// To prevent unexpected "Content stream has been drained" errors caused by changing environments, we flag
 		//	the resource content as "drained" every time a stream is requested. Even if actually a buffer or
 		//	createStream callback is being used.
-		this._contentDrained = true;
+		this.#contentDrained = true;
 		return contentStream;
 	}
 
@@ -222,24 +236,24 @@ class Resource {
 	 														callback for dynamic creation of a readable stream
 	 */
 	setStream(stream) {
-		this._isModified = true;
-		if (this._sourceMetadata) {
-			this._sourceMetadata.contentModified = true;
+		this.#isModified = true;
+		if (this.#sourceMetadata) {
+			this.#sourceMetadata.contentModified = true;
 		}
 
-		this._buffer = null;
-		// if (this._stream) { // TODO this may cause strange issues
-		// 	this._stream.destroy();
+		this.#buffer = null;
+		// if (this.#stream) { // TODO this may cause strange issues
+		// 	this.#stream.destroy();
 		// }
 		if (typeof stream === "function") {
-			this._createStream = stream;
-			this._stream = null;
+			this.#createStream = stream;
+			this.#stream = null;
 		} else {
-			this._stream = stream;
-			this._createStream = null;
+			this.#stream = stream;
+			this.#createStream = null;
 		}
-		this._contentDrained = false;
-		this._streamDrained = false;
+		this.#contentDrained = false;
+		this.#streamDrained = false;
 	}
 
 	/**
@@ -249,7 +263,7 @@ class Resource {
 	 * @returns {string} (Virtual) path of the resource
 	 */
 	getPath() {
-		return this._path;
+		return this.#path;
 	}
 
 	/**
@@ -259,8 +273,8 @@ class Resource {
 	 * @param {string} path (Virtual) path of the resource
 	 */
 	setPath(path) {
-		this._path = path;
-		this._name = Resource._getNameFromPath(path);
+		this.#path = path;
+		this.#name = Resource._getNameFromPath(path);
 	}
 
 	/**
@@ -270,7 +284,7 @@ class Resource {
 	 * @returns {string} Name of the resource
 	 */
 	getName() {
-		return this._name;
+		return this.#name;
 	}
 
 	/**
@@ -284,7 +298,7 @@ class Resource {
 	 *								or similar object
 	 */
 	getStatInfo() {
-		return this._statInfo;
+		return this.#statInfo;
 	}
 
 	/**
@@ -295,7 +309,7 @@ class Resource {
 	 */
 	async getSize() {
 		// if resource does not have any content it should have 0 bytes
-		if (!this._buffer && !this._createStream && !this._stream) {
+		if (!this.#buffer && !this.#createStream && !this.#stream) {
 			return 0;
 		}
 		const buffer = await this.getBuffer();
@@ -308,7 +322,7 @@ class Resource {
 	 * @param {string} name Resource collection name
 	 */
 	pushCollection(name) {
-		this._collections.push(name);
+		this.#collections.push(name);
 	}
 
 	/**
@@ -318,23 +332,23 @@ class Resource {
 	 * @returns {Promise<@ui5/fs/Resource>} Promise resolving with the clone
 	 */
 	async clone() {
-		const options = await this._getCloneOptions();
+		const options = await this.#getCloneOptions();
 		return new Resource(options);
 	}
 
-	async _getCloneOptions() {
+	async #getCloneOptions() {
 		const options = {
-			path: this._path,
-			statInfo: clone(this._statInfo),
-			sourceMetadata: clone(this._sourceMetadata)
+			path: this.#path,
+			statInfo: clone(this.#statInfo),
+			sourceMetadata: clone(this.#sourceMetadata)
 		};
 
-		if (this._stream) {
-			options.buffer = await this._getBufferFromStream();
-		} else if (this._createStream) {
-			options.createStream = this._createStream;
-		} else if (this._buffer) {
-			options.buffer = this._buffer;
+		if (this.#stream) {
+			options.buffer = await this.#getBufferFromStream();
+		} else if (this.#createStream) {
+			options.createStream = this.#createStream;
+		} else if (this.#buffer) {
+			options.buffer = this.#buffer;
 		}
 
 		return options;
@@ -354,7 +368,7 @@ class Resource {
 	 * @returns {@ui5/project/specifications/Project} Project this resource is associated with
 	 */
 	getProject() {
-		return this.__project;
+		return this.#project;
 	}
 
 	/**
@@ -364,11 +378,11 @@ class Resource {
 	 * @param {@ui5/project/specifications/Project} project Project this resource is associated with
 	 */
 	setProject(project) {
-		if (this.__project) {
-			throw new Error(`Unable to assign project ${project.getName()} to resource ${this._path}: ` +
-				`Resource is already associated to project ${this.__project}`);
+		if (this.#project) {
+			throw new Error(`Unable to assign project ${project.getName()} to resource ${this.#path}: ` +
+				`Resource is already associated to project ${this.#project}`);
 		}
-		this.__project = project;
+		this.#project = project;
 	}
 
 	/**
@@ -378,7 +392,7 @@ class Resource {
 	 * @returns {boolean} True if the resource is associated with a project
 	 */
 	hasProject() {
-		return !!this.__project;
+		return !!this.#project;
 	}
 
 	/**
@@ -388,7 +402,7 @@ class Resource {
 	 * @returns {boolean} True if the resource's content has been changed
 	 */
 	isModified() {
-		return this._isModified;
+		return this.#isModified;
 	}
 
 	/**
@@ -399,10 +413,10 @@ class Resource {
 	getPathTree() {
 		const tree = Object.create(null);
 
-		let pointer = tree[this._path] = Object.create(null);
+		let pointer = tree[this.#path] = Object.create(null);
 
-		for (let i = this._collections.length - 1; i >= 0; i--) {
-			pointer = pointer[this._collections[i]] = Object.create(null);
+		for (let i = this.#collections.length - 1; i >= 0; i--) {
+			pointer = pointer[this.#collections[i]] = Object.create(null);
 		}
 
 		return tree;
@@ -415,7 +429,7 @@ class Resource {
 	 * @returns {object|null}
 	 */
 	getSourceMetadata() {
-		return this._sourceMetadata || null;
+		return this.#sourceMetadata || null;
 	}
 
 	/**
@@ -424,15 +438,15 @@ class Resource {
 	 * @private
 	 * @returns {stream.Readable} Readable stream
 	 */
-	_getStream() {
-		if (this._streamDrained) {
-			throw new Error(`Content stream of Resource ${this._path} is flagged as drained.`);
+	#getStream() {
+		if (this.#streamDrained) {
+			throw new Error(`Content stream of Resource ${this.#path} is flagged as drained.`);
 		}
-		if (this._createStream) {
-			return this._createStream();
+		if (this.#createStream) {
+			return this.#createStream();
 		}
-		this._streamDrained = true;
-		return this._stream;
+		this.#streamDrained = true;
+		return this.#stream;
 	}
 
 	/**
@@ -441,12 +455,12 @@ class Resource {
 	 * @private
 	 * @returns {Promise<Buffer>} Promise resolving with buffer.
 	 */
-	_getBufferFromStream() {
-		if (this._buffering) { // Prevent simultaneous buffering, causing unexpected access to drained stream
-			return this._buffering;
+	#getBufferFromStream() {
+		if (this.#buffering) { // Prevent simultaneous buffering, causing unexpected access to drained stream
+			return this.#buffering;
 		}
-		return this._buffering = new Promise((resolve, reject) => {
-			const contentStream = this._getStream();
+		return this.#buffering = new Promise((resolve, reject) => {
+			const contentStream = this.#getStream();
 			const buffers = [];
 			contentStream.on("data", (data) => {
 				buffers.push(data);
@@ -456,8 +470,8 @@ class Resource {
 			});
 			contentStream.on("end", () => {
 				const buffer = Buffer.concat(buffers);
-				this._setBuffer(buffer);
-				this._buffering = null;
+				this.#setBuffer(buffer);
+				this.#buffering = null;
 				resolve(buffer);
 			});
 		});

--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -6,7 +6,7 @@ const fnTrue = () => true;
 const fnFalse = () => false;
 
 /**
- * Resource
+ * Resource. UI5 Tooling specific representation of a file's content and metadata
  *
  * @public
  * @class
@@ -22,7 +22,6 @@ class Resource {
 	*/
 
 	/**
-	 * The constructor.
 	 *
 	 * @public
 	 * @param {object} parameters Parameters
@@ -40,9 +39,10 @@ class Resource {
 	 *					string or stream).
 	 *					In some cases this is the most memory-efficient way to supply resource content
 	 * @param {@ui5/project/specifications/Project} [parameters.project] Project this resource is associated with
-	 * @param {object} [parameters.source] Experimental, internal parameter. Do not use
+	 * @param {object} [parameters.sourceMetadata] Source metadata for UI5 Tooling internal use.
+	 * 	Typically set by an adapter to store information for later retrieval.
 	 */
-	constructor({path, statInfo, buffer, string, createStream, stream, project, source}) {
+	constructor({path, statInfo, buffer, string, createStream, stream, project, sourceMetadata}) {
 		if (!path) {
 			throw new Error("Cannot create Resource: path parameter missing");
 		}
@@ -55,10 +55,13 @@ class Resource {
 		this._path = path;
 		this._name = Resource._getNameFromPath(path);
 
-		this._source = source; // Experimental, internal parameter
-		if (this._source) {
-			// Indicator for adapters like FileSystem to detect whether a resource has been changed
-			this._source.modified = this._source.modified || false;
+		this._sourceMetadata = sourceMetadata;
+		if (this._sourceMetadata) {
+			// This flag indicates whether a resource has changed from its original source.
+			// resource.isModified() is not sufficient, since it only reflects the modification state of the
+			// current instance.
+			// Since the sourceMetadata object is inherited to clones, it is the only correct indicator
+			this._sourceMetadata.contentModified = this._sourceMetadata.contentModified || false;
 		}
 		this.__project = project; // Two underscores since "_project" was widely used in UI5 Tooling 2.0
 
@@ -92,6 +95,8 @@ class Resource {
 
 		// Tracing:
 		this._collections = [];
+
+		this._isModified = false;
 	}
 
 	static _getNameFromPath(virPath) {
@@ -126,9 +131,14 @@ class Resource {
 	 * @param {Buffer} buffer Buffer instance
 	 */
 	setBuffer(buffer) {
-		if (this._source && !this._source.modified) {
-			this._source.modified = true;
+		if (this._sourceMetadata) {
+			this._sourceMetadata.contentModified = true;
 		}
+		this._isModified = true;
+		this._setBuffer(buffer);
+	}
+
+	_setBuffer(buffer) {
 		this._createStream = null;
 		// if (this._stream) { // TODO this may cause strange issues
 		// 	this._stream.destroy();
@@ -212,9 +222,11 @@ class Resource {
 	 														callback for dynamic creation of a readable stream
 	 */
 	setStream(stream) {
-		if (this._source && !this._source.modified) {
-			this._source.modified = true;
+		this._isModified = true;
+		if (this._sourceMetadata) {
+			this._sourceMetadata.contentModified = true;
 		}
+
 		this._buffer = null;
 		// if (this._stream) { // TODO this may cause strange issues
 		// 	this._stream.destroy();
@@ -314,7 +326,7 @@ class Resource {
 		const options = {
 			path: this._path,
 			statInfo: clone(this._statInfo),
-			source: clone(this._source)
+			sourceMetadata: clone(this._sourceMetadata)
 		};
 
 		if (this._stream) {
@@ -370,6 +382,16 @@ class Resource {
 	}
 
 	/**
+	 * Check whether the content of this resource has been changed during its life cycle
+	 *
+	 * @public
+	 * @returns {boolean} True if the resource's content has been changed
+	 */
+	isModified() {
+		return this._isModified;
+	}
+
+	/**
 	 * Tracing: Get tree for printing out trace
 	 *
 	 * @returns {object} Trace tree
@@ -386,8 +408,14 @@ class Resource {
 		return tree;
 	}
 
-	getSource() {
-		return this._source || {};
+	/**
+	 * Returns source metadata if any where provided during the creation of this resource.
+	 * Typically set by an adapter to store information for later retrieval.
+	 *
+	 * @returns {object|null}
+	 */
+	getSourceMetadata() {
+		return this._sourceMetadata || null;
 	}
 
 	/**
@@ -428,15 +456,7 @@ class Resource {
 			});
 			contentStream.on("end", () => {
 				const buffer = Buffer.concat(buffers);
-				let modified;
-				if (this._source) {
-					modified = this._source.modified;
-				}
-				this.setBuffer(buffer);
-				// Modified flag should be reset as the resource hasn't been modified from the outside
-				if (this._source) {
-					this._source.modified = modified;
-				}
+				this._setBuffer(buffer);
 				this._buffering = null;
 				resolve(buffer);
 			});

--- a/lib/ResourceFacade.js
+++ b/lib/ResourceFacade.js
@@ -9,12 +9,11 @@ import Resource from "./Resource.js";
  */
 class ResourceFacade {
 	/**
-	 * The constructor.
 	 *
 	 * @public
 	 * @param {object} parameters Parameters
-	 * @param {string} parameters.path Virtual path
-	 * @param {@ui5/fs/Resource} parameters.resource Resource to cover
+	 * @param {string} parameters.path Virtual path of the facade resource
+	 * @param {@ui5/fs/Resource} parameters.resource Resource to conceal
 	 */
 	constructor({path, resource}) {
 		if (!path) {
@@ -221,13 +220,34 @@ class ResourceFacade {
 	hasProject() {
 		return this._resource.hasProject();
 	}
-
-	getConcealedResource() {
-		return this._resource;
+	/**
+	 * Check whether the content of this resource has been changed during its life cycle
+	 *
+	 * @public
+	 * @returns {boolean} True if the resource's content has been changed
+	 */
+	isModified() {
+		return this._resource.isModified();
 	}
 
-	getSource() {
-		return this._resource.getSource();
+	/**
+	 * Returns source metadata if any where provided during the creation of this resource.
+	 * Typically set by an adapter to store information for later retrieval.
+	 *
+	 * @returns {object|null}
+	 */
+	getSourceMetadata() {
+		return this._resource.getSourceMetadata();
+	}
+
+
+	/**
+	 * Returns the resource concealed by this facade
+	 *
+	 * @returns {@ui5/fs/Resource}
+	 */
+	getConcealedResource() {
+		return this._resource;
 	}
 }
 

--- a/lib/ResourceFacade.js
+++ b/lib/ResourceFacade.js
@@ -8,6 +8,10 @@ import Resource from "./Resource.js";
  * @alias @ui5/fs/ResourceFacade
  */
 class ResourceFacade {
+	#path;
+	#name;
+	#resource;
+
 	/**
 	 *
 	 * @public
@@ -22,9 +26,9 @@ class ResourceFacade {
 		if (!resource) {
 			throw new Error("Cannot create ResourceFacade: resource parameter missing");
 		}
-		this._path = path;
-		this._name = Resource._getNameFromPath(path);
-		this._resource = resource;
+		this.#path = path;
+		this.#name = Resource._getNameFromPath(path);
+		this.#resource = resource;
 	}
 
 	/**
@@ -34,7 +38,7 @@ class ResourceFacade {
 	 * @returns {string} (Virtual) path of the resource
 	 */
 	getPath() {
-		return this._path;
+		return this.#path;
 	}
 
 	/**
@@ -44,7 +48,7 @@ class ResourceFacade {
 	 * @returns {string} Name of the resource
 	 */
 	getName() {
-		return this._name;
+		return this.#name;
 	}
 
 	/**
@@ -66,7 +70,7 @@ class ResourceFacade {
 	 */
 	async clone() {
 		// Cloning resolves the facade
-		const resourceClone = await this._resource.clone();
+		const resourceClone = await this.#resource.clone();
 		resourceClone.setPath(this.getPath());
 		return resourceClone;
 	}
@@ -83,7 +87,7 @@ class ResourceFacade {
 	 * @returns {Promise<Buffer>} Promise resolving with a buffer of the resource content.
 	 */
 	async getBuffer() {
-		return this._resource.getBuffer();
+		return this.#resource.getBuffer();
 	}
 
 	/**
@@ -93,7 +97,7 @@ class ResourceFacade {
 	 * @param {Buffer} buffer Buffer instance
 	 */
 	setBuffer(buffer) {
-		return this._resource.setBuffer(buffer);
+		return this.#resource.setBuffer(buffer);
 	}
 
 	/**
@@ -103,7 +107,7 @@ class ResourceFacade {
 	 * @returns {Promise<string>} Promise resolving with the resource content.
 	 */
 	getString() {
-		return this._resource.getString();
+		return this.#resource.getString();
 	}
 
 	/**
@@ -113,7 +117,7 @@ class ResourceFacade {
 	 * @param {string} string Resource content
 	 */
 	setString(string) {
-		return this._resource.setString(string);
+		return this.#resource.setString(string);
 	}
 
 	/**
@@ -128,7 +132,7 @@ class ResourceFacade {
 	 * @returns {stream.Readable} Readable stream for the resource content.
 	 */
 	getStream() {
-		return this._resource.getStream();
+		return this.#resource.getStream();
 	}
 
 	/**
@@ -139,7 +143,7 @@ class ResourceFacade {
 															callback for dynamic creation of a readable stream
 	 */
 	setStream(stream) {
-		return this._resource.setStream(stream);
+		return this.#resource.setStream(stream);
 	}
 
 	/**
@@ -153,7 +157,7 @@ class ResourceFacade {
 	 *								or similar object
 	 */
 	getStatInfo() {
-		return this._resource.getStatInfo();
+		return this.#resource.getStatInfo();
 	}
 
 	/**
@@ -163,7 +167,7 @@ class ResourceFacade {
 	 * @returns {Promise<number>} size in bytes, <code>0</code> if there is no content yet
 	 */
 	async getSize() {
-		return this._resource.getSize();
+		return this.#resource.getSize();
 	}
 
 	/**
@@ -172,7 +176,7 @@ class ResourceFacade {
 	 * @param {string} name Resource collection name
 	 */
 	pushCollection(name) {
-		return this._resource.pushCollection(name);
+		return this.#resource.pushCollection(name);
 	}
 
 	/**
@@ -181,7 +185,7 @@ class ResourceFacade {
 	 * @returns {object} Trace tree
 	 */
 	getPathTree() {
-		return this._resource.getPathTree();
+		return this.#resource.getPathTree();
 	}
 
 	/**
@@ -198,7 +202,7 @@ class ResourceFacade {
 	 * @returns {@ui5/project/specifications/Project} Project this resource is associated with
 	 */
 	getProject() {
-		return this._resource.getProject();
+		return this.#resource.getProject();
 	}
 
 	/**
@@ -208,7 +212,7 @@ class ResourceFacade {
 	 * @param {@ui5/project/specifications/Project} project Project this resource is associated with
 	 */
 	setProject(project) {
-		return this._resource.setProject(project);
+		return this.#resource.setProject(project);
 	}
 
 	/**
@@ -218,7 +222,7 @@ class ResourceFacade {
 	 * @returns {boolean} True if the resource is associated with a project
 	 */
 	hasProject() {
-		return this._resource.hasProject();
+		return this.#resource.hasProject();
 	}
 	/**
 	 * Check whether the content of this resource has been changed during its life cycle
@@ -227,7 +231,7 @@ class ResourceFacade {
 	 * @returns {boolean} True if the resource's content has been changed
 	 */
 	isModified() {
-		return this._resource.isModified();
+		return this.#resource.isModified();
 	}
 
 	/**
@@ -237,7 +241,7 @@ class ResourceFacade {
 	 * @returns {object|null}
 	 */
 	getSourceMetadata() {
-		return this._resource.getSourceMetadata();
+		return this.#resource.getSourceMetadata();
 	}
 
 
@@ -247,7 +251,7 @@ class ResourceFacade {
 	 * @returns {@ui5/fs/Resource}
 	 */
 	getConcealedResource() {
-		return this._resource;
+		return this.#resource;
 	}
 }
 

--- a/lib/adapters/FileSystem.js
+++ b/lib/adapters/FileSystem.js
@@ -12,7 +12,7 @@ import {PassThrough} from "node:stream";
 import AbstractAdapter from "./AbstractAdapter.js";
 
 const READ_ONLY_MODE = 0o444;
-
+const ADAPTER_NAME = "FileSystem";
 /**
  * File system resource adapter
  *
@@ -70,8 +70,8 @@ class FileSystem extends AbstractAdapter {
 							project: this._project,
 							statInfo: stat,
 							path: this._virBaseDir,
-							source: {
-								adapter: "FileSystem",
+							sourceMetadata: {
+								adapter: ADAPTER_NAME,
 								fsPath: this._fsBasePath
 							},
 							createStream: () => {
@@ -106,8 +106,8 @@ class FileSystem extends AbstractAdapter {
 								project: this._project,
 								statInfo: stat,
 								path: virPath,
-								source: {
-									adapter: "FileSystem",
+								sourceMetadata: {
+									adapter: ADAPTER_NAME,
 									fsPath: fsPath
 								},
 								createStream: () => {
@@ -182,8 +182,8 @@ class FileSystem extends AbstractAdapter {
 				project: this._project,
 				statInfo,
 				path: virPath,
-				source: {
-					adapter: "FileSystem",
+				sourceMetadata: {
+					adapter: ADAPTER_NAME,
 					fsPath
 				}
 			};
@@ -237,28 +237,45 @@ class FileSystem extends AbstractAdapter {
 
 		await mkdir(dirPath, {recursive: true});
 
-		const resourceSource = resource.getSource();
-		if (!resourceSource.modified && resourceSource.adapter === "FileSystem" && resourceSource.fsPath) {
-			// fs.copyFile can be used when the resource is from FS and hasn't been modified
-			// In addition, nothing needs to be done when src === dest
-			if (resourceSource.fsPath === fsPath) {
-				log.silly(`Skip writing to ${fsPath} (Resource hasn't been modified)`);
-			} else {
-				log.silly(`Copying resource from ${resourceSource.fsPath} to ${fsPath}`);
-				await copyFile(resourceSource.fsPath, fsPath);
+		const sourceMetadata = resource.getSourceMetadata();
+		if (sourceMetadata && sourceMetadata.adapter === ADAPTER_NAME && sourceMetadata.fsPath) {
+			// Resource has been created by FileSystem adapter. This means it might require special handling
+
+			/* The following code covers these four conditions:
+				1. FS-paths not equal + Resource not modified => Shortcut: Use fs.copyFile
+				2. FS-paths equal + Resource not modified => Shortcut: Skip write altogether
+				3. FS-paths equal + Resource modified => Drain stream into buffer. Later write from buffer as usual
+				4. FS-paths not equal + Resource modified => No special handling. Write from stream or buffer
+			*/
+
+			if (sourceMetadata.fsPath !== fsPath && !sourceMetadata.contentModified) {
+				// Shortcut: fs.copyFile can be used when the resource hasn't been modified
+				log.silly(`Resource hasn't been modified. Copying resource from ${sourceMetadata.fsPath} to ${fsPath}`);
+				await copyFile(sourceMetadata.fsPath, fsPath);
 				if (readOnly) {
 					await chmod(fsPath, READ_ONLY_MODE);
 				}
-			}
-			return;
+				return;
+			} else if (sourceMetadata.fsPath === fsPath && !sourceMetadata.contentModified) {
+				log.silly(
+					`Resource hasn't been modified, target path equals source path. Skipping write to ${fsPath}`);
+				if (readOnly) {
+					await chmod(fsPath, READ_ONLY_MODE);
+				}
+				return;
+			} else if (sourceMetadata.fsPath === fsPath && sourceMetadata.contentModified) {
+				// Resource has been modified. Make sure all streams are drained to prevent
+				// issues caused by piping the original read-stream into a write-stream for the same path
+				await resource.getBuffer();
+			} else {/* Different paths + modifications require no special handling */}
 		}
 
 		log.silly(`Writing to ${fsPath}`);
 
-		return new Promise((resolve, reject) => {
+		await new Promise((resolve, reject) => {
 			let contentStream;
 
-			if ((drain || readOnly) && resourceSource.fsPath !== fsPath) {
+			if (drain || readOnly) {
 				// Stream will be drained
 				contentStream = resource.getStream();
 
@@ -292,16 +309,26 @@ class FileSystem extends AbstractAdapter {
 				reject(err);
 			});
 			write.on("close", (ex) => {
-				if (readOnly) {
-					// Create new stream from written file
-					resource.setStream(function() {
-						return fs.createReadStream(fsPath);
-					});
-				}
 				resolve();
 			});
 			contentStream.pipe(write);
 		});
+
+		if (readOnly) {
+			if (sourceMetadata?.fsPath === fsPath) {
+				// When streaming into the same file, permissions need to be changed explicitly
+				await chmod(fsPath, READ_ONLY_MODE);
+			}
+
+			// In case of readOnly, we drained the stream and can now set a new callback
+			// for creating a stream from written file
+			// This should be identical to buffering the resource content in memory, since the written file
+			// can not be modified.
+			// We chose this approach to be more memory efficient in scenarios where readOnly is used
+			resource.setStream(function() {
+				return fs.createReadStream(fsPath);
+			});
+		}
 	}
 }
 

--- a/lib/adapters/Memory.js
+++ b/lib/adapters/Memory.js
@@ -3,6 +3,8 @@ const log = logger.getLogger("resources:adapters:Memory");
 import micromatch from "micromatch";
 import AbstractAdapter from "./AbstractAdapter.js";
 
+const ADAPTER_NAME = "Memory";
+
 /**
  * Virtual resource Adapter
  *
@@ -76,8 +78,8 @@ class Memory extends AbstractAdapter {
 							return true;
 						}
 					},
-					source: {
-						adapter: "Memory"
+					sourceMetadata: {
+						adapter: ADAPTER_NAME
 					},
 					path: this._virBasePath.slice(0, -1)
 				})
@@ -155,8 +157,8 @@ class Memory extends AbstractAdapter {
 			if (!this._virDirs[segment]) {
 				this._virDirs[segment] = this._createResource({
 					project: this._project,
-					source: {
-						adapter: "Memory"
+					sourceMetadata: {
+						adapter: ADAPTER_NAME
 					},
 					statInfo: { // TODO: make closer to fs stat info
 						isDirectory: function() {

--- a/test/lib/adapters/FileSystem_write_large_file.js
+++ b/test/lib/adapters/FileSystem_write_large_file.js
@@ -7,7 +7,11 @@ import FileSystem from "../../../lib/adapters/FileSystem.js";
 import Resource from "../../../lib/Resource.js";
 import path from "node:path";
 
-test.serial("x", async (t) => {
+test.serial("Stream a large file from source to target", async (t) => {
+	// This test used to fail. The FileSystem adapter would directly pipe the read-stream into a write stream with the
+	// same path. Leading to only the first chunk of the source file or nothing at all being written into the target
+	// This has been fixed with https://github.com/SAP/ui5-fs/pull/472
+
 	const fsBasePath = fileURLToPath(new URL("../../tmp/adapters/FileSystemWriteLargeFile/", import.meta.url));
 
 	const fileSystem = new FileSystem({
@@ -15,8 +19,7 @@ test.serial("x", async (t) => {
 		virBasePath: "/"
 	});
 
-	// const largeBuffer = Buffer.alloc(1048576); // 1MB
-	const largeBuffer = Buffer.alloc(1);
+	const largeBuffer = Buffer.alloc(1048576); // 1MB
 
 	await fileSystem.write(new Resource({
 		path: "/large-file.txt",
@@ -32,6 +35,6 @@ test.serial("x", async (t) => {
 
 	await fileSystem.write(largeResource);
 
-	t.deepEqual(await readFile(path.join(fsBasePath, "large-file.txt")), largeBuffer,
+	t.deepEqual((await readFile(path.join(fsBasePath, "large-file.txt"))).length, largeBuffer.length,
 		"Large file should be overwritten with exact same contents");
 });

--- a/test/lib/adapters/FileSystem_write_large_file.js
+++ b/test/lib/adapters/FileSystem_write_large_file.js
@@ -1,0 +1,37 @@
+import test from "ava";
+import {fileURLToPath} from "node:url";
+import {Buffer} from "node:buffer";
+import {readFile} from "node:fs/promises";
+
+import FileSystem from "../../../lib/adapters/FileSystem.js";
+import Resource from "../../../lib/Resource.js";
+import path from "node:path";
+
+test.serial("x", async (t) => {
+	const fsBasePath = fileURLToPath(new URL("../../tmp/adapters/FileSystemWriteLargeFile/", import.meta.url));
+
+	const fileSystem = new FileSystem({
+		fsBasePath,
+		virBasePath: "/"
+	});
+
+	// const largeBuffer = Buffer.alloc(1048576); // 1MB
+	const largeBuffer = Buffer.alloc(1);
+
+	await fileSystem.write(new Resource({
+		path: "/large-file.txt",
+		buffer: largeBuffer
+	}));
+
+	t.deepEqual(await readFile(path.join(fsBasePath, "large-file.txt")), largeBuffer,
+		"Large file should be written as expected");
+
+	const largeResource = await fileSystem.byPath("/large-file.txt");
+
+	largeResource.setStream(largeResource.getStream());
+
+	await fileSystem.write(largeResource);
+
+	t.deepEqual(await readFile(path.join(fsBasePath, "large-file.txt")), largeBuffer,
+		"Large file should be overwritten with exact same contents");
+});

--- a/test/lib/adapters/Memory_read.js
+++ b/test/lib/adapters/Memory_read.js
@@ -161,7 +161,7 @@ test("glob a specific filetype (yaml)", async (t) => {
 
 	const resources = await readerWriter.byGlob("/**/*.yaml");
 	resources.forEach((res) => {
-		t.is(res._name, "ui5.yaml");
+		t.is(res.getName(), "ui5.yaml");
 	});
 });
 
@@ -225,7 +225,7 @@ test("glob (normalized) root directory (=> fs root)", async (t) => {
 		"/*",
 	], {nodir: false});
 	resources.forEach((res) => {
-		t.is(res._name, "app");
+		t.is(res.getName(), "app");
 		t.is(res.getStatInfo().isDirectory(), true);
 	});
 });

--- a/test/lib/glob.js
+++ b/test/lib/glob.js
@@ -118,7 +118,7 @@ test("glob only a specific filetype (yaml)", async (t) => {
 	const resources = await t.context.readerWriter.filesystem.byGlob("/**/*.yaml");
 
 	resources.forEach((res) => {
-		t.is(res._name, "ui5.yaml");
+		t.is(res.getName(), "ui5.yaml");
 	});
 });
 
@@ -145,7 +145,7 @@ test("glob only a specific filetype (json) with exclude pattern", async (t) => {
 	]);
 
 	resources.forEach((res) => {
-		t.is(res._name, "manifest.json");
+		t.is(res.getName(), "manifest.json");
 	});
 });
 
@@ -169,7 +169,7 @@ test("glob (normalized) root directory (=> fs root)", async (t) => {
 	], {nodir: false});
 
 	resources.forEach((res) => {
-		t.is(res._name, "test-resources");
+		t.is(res.getName(), "test-resources");
 		t.is(res.getStatInfo().isDirectory(), true);
 	});
 });
@@ -190,7 +190,7 @@ test("glob subdirectory", async (t) => {
 	], {nodir: false});
 
 	resources.forEach((res) => {
-		t.is(res._name, "application.a");
+		t.is(res.getName(), "application.a");
 		t.is(res.getStatInfo().isDirectory(), true);
 	});
 });


### PR DESCRIPTION
This allows to check whether the content of a resource has been
modified.

For example, if a build processor did not modify a resource, one could
omit writing it into the workspace resource collection. If a resource
has not been modified during the build process and has not been written
into the workspace, the FileSystem adapter can optimize the write
process, for example by using fs.copyFile.

Also in this change:
* Rename internal Resource parameter 'source' to 'sourceMetadata' and
  contained flag 'modified' to 'contentModified'
* FileSystem adapter: Do not stream into the same file when writing.
  Refactor related code
* Adding a test for writing large files to the same path as the source