### PR TITLE
[INTERNAL] Resource: Do not flag as modified during creation

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -77,6 +77,8 @@ class Resource {
 			// Since the sourceMetadata object is inherited to clones, it is the only correct indicator
 			this.#sourceMetadata.contentModified = this.#sourceMetadata.contentModified || false;
 		}
+		this.#isModified = false;
+
 		this.#project = project;
 
 		this.#statInfo = statInfo || { // TODO
@@ -102,15 +104,15 @@ class Resource {
 		} else if (stream) {
 			this.#stream = stream;
 		} else if (buffer) {
-			this.setBuffer(buffer);
+			// Use private setter, not to accidentally set any modified flags
+			this.#setBuffer(buffer);
 		} else if (typeof string === "string" || string instanceof String) {
-			this.setString(string);
+			// Use private setter, not to accidentally set any modified flags
+			this.#setBuffer(Buffer.from(string, "utf8"));
 		}
 
 		// Tracing:
 		this.#collections = [];
-
-		this.#isModified = false;
 	}
 
 	static _getNameFromPath(virPath) {

--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -185,13 +185,20 @@ class AbstractAdapter extends AbstractReaderWriter {
 		return new Resource(parameters);
 	}
 
-	async _migrateResource(resource) {
+	_migrateResource(resource) {
+		// This function only returns a promise if a migration is necessary.
+		// Since this is rarely the case, we therefore reduce the amount of
+		// created Promises by making this differentiation
+
 		// Check if its a fs/Resource v3, function 'hasProject' was
 		// introduced with v3 therefore take it as the indicator
 		if (resource.hasProject) {
 			return resource;
 		}
+		return this._createFromLegacyResource(resource);
+	}
 
+	async _createFromLegacyResource(resource) {
 		const options = {
 			path: resource._path,
 			statInfo: resource._statInfo,

--- a/lib/adapters/FileSystem.js
+++ b/lib/adapters/FileSystem.js
@@ -224,7 +224,12 @@ class FileSystem extends AbstractAdapter {
 	 * @returns {Promise<undefined>} Promise resolving once data has been written
 	 */
 	async _write(resource, {drain, readOnly}) {
-		resource = await this._migrateResource(resource);
+		resource = this._migrateResource(resource);
+		if (resource instanceof Promise) {
+			// Only await if the migrate function returned a promise
+			// Otherwise await would automatically create a Promise, causing unwanted overhead
+			resource = await resource;
+		}
 		super._write(resource);
 		if (drain && readOnly) {
 			throw new Error(`Error while writing resource ${resource.getPath()}: ` +

--- a/lib/adapters/Memory.js
+++ b/lib/adapters/Memory.js
@@ -134,7 +134,12 @@ class Memory extends AbstractAdapter {
 	 * @returns {Promise<undefined>} Promise resolving once data has been written
 	 */
 	async _write(resource) {
-		resource = await this._migrateResource(resource);
+		resource = this._migrateResource(resource);
+		if (resource instanceof Promise) {
+			// Only await if the migrate function returned a promise
+			// Otherwise await would automatically create a Promise, causing unwanted overhead
+			resource = await resource;
+		}
 		super._write(resource);
 		const relPath = resource.getPath().substr(this._virBasePath.length);
 		log.silly(`Writing to virtual path ${resource.getPath()}`);


### PR DESCRIPTION
This is a follow-up of https://github.com/SAP/ui5-fs/pull/472

The setBuffer/setString calls in the constructor lead to the
sourceMetadata.contentModified flag being set to true, even though the
content has not been modified. To resolve this, use the internal
setter, which does not set any modification flags.