### PR TITLE
[INTERNAL] Resource/Adapters: Enforce absolute paths, resolve all paths before use

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -1,6 +1,6 @@
 import stream from "node:stream";
 import clone from "clone";
-import path from "node:path";
+import posixPath from "node:path/posix";
 
 const fnTrue = () => true;
 const fnFalse = () => false;
@@ -39,7 +39,7 @@ class Resource {
 	 *
 	 * @public
 	 * @param {object} parameters Parameters
-	 * @param {string} parameters.path Virtual path
+	 * @param {string} parameters.path Absolute virtual path of the resource
 	 * @param {fs.Stats|object} [parameters.statInfo] File information. Instance of
 	 *					[fs.Stats]{@link https://nodejs.org/api/fs.html#fs_class_fs_stats} or similar object
 	 * @param {Buffer} [parameters.buffer] Content of this resources as a Buffer instance
@@ -58,16 +58,15 @@ class Resource {
 	 */
 	constructor({path, statInfo, buffer, string, createStream, stream, project, sourceMetadata}) {
 		if (!path) {
-			throw new Error("Cannot create Resource: path parameter missing");
+			throw new Error("Unable to create Resource: Missing parameter 'path'");
 		}
 		if (buffer && createStream || buffer && string || string && createStream || buffer && stream ||
 				string && stream || createStream && stream) {
-			throw new Error("Cannot create Resource: Please set only one content parameter. " +
-				"Buffer, string, stream or createStream");
+			throw new Error("Unable to create Resource: Please set only one content parameter. " +
+				"'buffer', 'string', 'stream' or 'createStream'");
 		}
 
-		this.#path = path;
-		this.#name = Resource._getNameFromPath(path);
+		this.setPath(path);
 
 		this.#sourceMetadata = sourceMetadata;
 		if (this.#sourceMetadata) {
@@ -113,10 +112,6 @@ class Resource {
 
 		// Tracing:
 		this.#collections = [];
-	}
-
-	static _getNameFromPath(virPath) {
-		return path.posix.basename(virPath);
 	}
 
 	/**
@@ -259,24 +254,28 @@ class Resource {
 	}
 
 	/**
-	 * Gets the resources path
+	 * Gets the virtual resources path
 	 *
 	 * @public
-	 * @returns {string} (Virtual) path of the resource
+	 * @returns {string} Virtual path of the resource
 	 */
 	getPath() {
 		return this.#path;
 	}
 
 	/**
-	 * Sets the resources path
+	 * Sets the virtual resources path
 	 *
 	 * @public
-	 * @param {string} path (Virtual) path of the resource
+	 * @param {string} path Absolute virtual path of the resource
 	 */
 	setPath(path) {
+		path = posixPath.normalize(path);
+		if (!posixPath.isAbsolute(path)) {
+			throw new Error(`Unable to set resource path: Path must be absolute: ${path}`);
+		}
 		this.#path = path;
-		this.#name = Resource._getNameFromPath(path);
+		this.#name = posixPath.basename(path);
 	}
 
 	/**

--- a/lib/ResourceFacade.js
+++ b/lib/ResourceFacade.js
@@ -1,4 +1,4 @@
-import Resource from "./Resource.js";
+import posixPath from "node:path/posix";
 
 /**
  * A {@link @ui5/fs/Resource Resource} with a different path than it's original
@@ -21,13 +21,17 @@ class ResourceFacade {
 	 */
 	constructor({path, resource}) {
 		if (!path) {
-			throw new Error("Cannot create ResourceFacade: path parameter missing");
+			throw new Error("Unable to create ResourceFacade: Missing parameter 'path'");
 		}
 		if (!resource) {
-			throw new Error("Cannot create ResourceFacade: resource parameter missing");
+			throw new Error("Unable to create ResourceFacade: Missing parameter 'resource'");
+		}
+		path = posixPath.normalize(path);
+		if (!posixPath.isAbsolute(path)) {
+			throw new Error(`Unable to create ResourceFacade: Parameter 'path' must be absolute: ${path}`);
 		}
 		this.#path = path;
-		this.#name = Resource._getNameFromPath(path);
+		this.#name = posixPath.basename(path);
 		this.#resource = resource;
 	}
 

--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -1,3 +1,4 @@
+import path from "node:path/posix";
 import {getLogger} from "@ui5/logger";
 const log = getLogger("resources:adapters:AbstractAdapter");
 import minimatch from "minimatch";
@@ -20,7 +21,8 @@ class AbstractAdapter extends AbstractReaderWriter {
 	 *
 	 * @public
 	 * @param {object} parameters Parameters
-	 * @param {string} parameters.virBasePath Virtual base path
+	 * @param {string} parameters.virBasePath
+	 *   Virtual base path. Must be absolute, POSIX-style, and must end with a slash
 	 * @param {string[]} [parameters.excludes] List of glob patterns to exclude
 	 * @param {object} [parameters.project] Experimental, internal parameter. Do not use
 	 */
@@ -29,8 +31,16 @@ class AbstractAdapter extends AbstractReaderWriter {
 			throw new TypeError("Class 'AbstractAdapter' is abstract");
 		}
 		super();
+
+		if (!virBasePath) {
+			throw new Error(`Unable to create adapter: Missing parameter 'virBasePath'`);
+		}
+		if (!path.isAbsolute(virBasePath)) {
+			throw new Error(`Unable to create adapter: Virtual base path must be absolute but is '${virBasePath}'`);
+		}
 		if (!virBasePath.endsWith("/")) {
-			throw new Error(`Virtual base path must end with a slash: ${virBasePath}`);
+			throw new Error(
+				`Unable to create adapter: Virtual base path must end with a slash but is '${virBasePath}'`);
 		}
 		this._virBasePath = virBasePath;
 		this._virBaseDir = virBasePath.slice(0, -1);
@@ -97,8 +107,21 @@ class AbstractAdapter extends AbstractReaderWriter {
 	 * @param {string} virPath Virtual Path
 	 * @returns {boolean} True if path is excluded, otherwise false
 	 */
-	isPathExcluded(virPath) {
+	_isPathExcluded(virPath) {
 		return micromatch(virPath, this._excludes).length > 0;
+	}
+
+	/**
+	 * Validate if virtual path should be handled by the adapter.
+	 * This means that it either starts with the virtual base path of the adapter
+	 * or equals the base directory (base path without a trailing slash)
+	 *
+	 * @param {string} virPath Virtual Path
+	 * @returns {boolean} True if path should be handled
+	 */
+	_isPathHandled(virPath) {
+		// Check whether path starts with base path, or equals base directory
+		return virPath.startsWith(this._virBasePath) || virPath === this._virBaseDir;
 	}
 
 	/**
@@ -215,12 +238,7 @@ class AbstractAdapter extends AbstractReaderWriter {
 		return new Resource(options);
 	}
 
-	_write(resource) {
-		if (!resource.getPath().startsWith(this._virBasePath)) {
-			throw new Error(`The path of the resource '${resource.getPath()}' does not start with ` +
-				`the configured virtual base path of the adapter '${this._virBasePath}'`);
-		}
-
+	_assignProjectToResource(resource) {
 		if (this._project) {
 			// Assign project to resource if necessary
 			if (resource.hasProject()) {
@@ -235,6 +253,45 @@ class AbstractAdapter extends AbstractReaderWriter {
 			log.silly(`Associating resource ${resource.getPath()} with project ${this._project.getName()}`);
 			resource.setProject(this._project);
 		}
+	}
+
+	_resolveVirtualPathToBase(inputVirPath, writeMode = false) {
+		if (!path.isAbsolute(inputVirPath)) {
+			throw new Error(`Failed to resolve virtual path '${inputVirPath}': Path must be absolute`);
+		}
+		// Resolve any ".." segments to make sure we compare the effective start of the path
+		// with the virBasePath
+		const virPath = path.normalize(inputVirPath);
+
+		if (!writeMode) {
+			// When reading resources, validate against path excludes and return null if the given path
+			// does not match this adapters base path
+			if (!this._isPathHandled(virPath)) {
+				if (log.isLevelEnabled("silly")) {
+					log.silly(`Failed to resolve virtual path '${inputVirPath}': ` +
+						`Resolved path does not start with adapter base path '${this._virBasePath}' or equals ` +
+						`base dir: ${this._virBaseDir}`);
+				}
+				return null;
+			}
+			if (this._isPathExcluded(virPath)) {
+				if (log.isLevelEnabled("silly")) {
+					log.silly(`Failed to resolve virtual path '${inputVirPath}': ` +
+						`Resolved path is excluded by configuration of adapter with base path '${this._virBasePath}'`);
+				}
+				return null;
+			}
+		} else if (!this._isPathHandled(virPath)) {
+			// Resolved path is not within the configured base path and does
+			// not equal the virtual base directory.
+			// Since we don't want to write resources to foreign locations, we throw an error
+			throw new Error(
+				`Failed to write resource with virtual path '${inputVirPath}': Path must start with ` +
+				`the configured virtual base path of the adapter. Base path: '${this._virBasePath}'`);
+		}
+
+		const relPath = virPath.substr(this._virBasePath.length);
+		return relPath;
 	}
 }
 

--- a/lib/adapters/FileSystem.js
+++ b/lib/adapters/FileSystem.js
@@ -26,8 +26,10 @@ class FileSystem extends AbstractAdapter {
 	 * The Constructor.
 	 *
 	 * @param {object} parameters Parameters
-	 * @param {string} parameters.virBasePath Virtual base path
-	 * @param {string} parameters.fsBasePath (Physical) File system path
+	 * @param {string} parameters.virBasePath
+	 *   Virtual base path. Must be absolute, POSIX-style, and must end with a slash
+	 * @param {string} parameters.fsBasePath
+	 *   File System base path. Must be absolute and must use platform-specific path segment separators
 	 * @param {string[]} [parameters.excludes] List of glob patterns to exclude
 	 * @param {object} [parameters.useGitignore=false]
 	 *   Whether to apply any excludes defined in an optional .gitignore in the given <code>fsBasePath</code> directory
@@ -35,7 +37,14 @@ class FileSystem extends AbstractAdapter {
 	 */
 	constructor({virBasePath, project, fsBasePath, excludes, useGitignore=false}) {
 		super({virBasePath, project, excludes});
-		this._fsBasePath = path.resolve(fsBasePath);
+
+		if (!fsBasePath) {
+			throw new Error(`Unable to create adapter: Missing parameter 'fsBasePath'`);
+		}
+
+		// Ensure path is resolved to an absolute path, ending with a slash (or backslash on Windows)
+		// path.resolve will always remove any trailing segment separator
+		this._fsBasePath = path.join(path.resolve(fsBasePath), path.sep);
 		this._useGitignore = !!useGitignore;
 	}
 
@@ -94,8 +103,16 @@ class FileSystem extends AbstractAdapter {
 			const matches = await globby(globbyPatterns, opt);
 			for (let i = matches.length - 1; i >= 0; i--) {
 				promises.push(new Promise((resolve, reject) => {
-					const fsPath = path.join(this._fsBasePath, matches[i]);
 					const virPath = (this._virBasePath + matches[i]);
+					const relPath = this._resolveVirtualPathToBase(virPath);
+					if (!relPath) {
+						// Match is likely outside adapter base path
+						log.verbose(
+							`Failed to resolve virtual path of glob match '${virPath}': Path must start with ` +
+							`the configured virtual base path of the adapter. Base path: '${this._virBasePath}'`);
+						resolve(null);
+					}
+					const fsPath = this._resolveToFileSystem(relPath);
 
 					// Workaround for not getting the stat from the glob
 					fs.stat(fsPath, (err, stat) => {
@@ -122,24 +139,22 @@ class FileSystem extends AbstractAdapter {
 		const results = await Promise.all(promises);
 
 		// Flatten results
-		return Array.prototype.concat.apply([], results);
+		return Array.prototype.concat.apply([], results).filter(($) => $);
 	}
 
 	/**
 	 * Locate a resource by path.
 	 *
 	 * @private
-	 * @param {string} virPath Virtual path
+	 * @param {string} virPath Absolute virtual path
 	 * @param {object} options Options
 	 * @param {@ui5/fs/tracing.Trace} trace Trace instance
 	 * @returns {Promise<@ui5/fs/Resource>} Promise resolving to a single resource or null if not found
 	 */
 	async _byPath(virPath, options, trace) {
-		if (this.isPathExcluded(virPath)) {
-			return null;
-		}
+		const relPath = this._resolveVirtualPathToBase(virPath);
 
-		if (!virPath.startsWith(this._virBasePath) && virPath !== this._virBaseDir) {
+		if (!relPath) {
 			// Neither starts with basePath, nor equals baseDirectory
 			if (!options.nodir && this._virBasePath.startsWith(virPath)) {
 				return this._createResource({
@@ -155,8 +170,8 @@ class FileSystem extends AbstractAdapter {
 				return null;
 			}
 		}
-		const relPath = virPath.substr(this._virBasePath.length);
-		const fsPath = path.join(this._fsBasePath, relPath);
+
+		const fsPath = this._resolveToFileSystem(relPath);
 
 		trace.pathCall();
 
@@ -230,14 +245,14 @@ class FileSystem extends AbstractAdapter {
 			// Otherwise await would automatically create a Promise, causing unwanted overhead
 			resource = await resource;
 		}
-		super._write(resource);
+		this._assignProjectToResource(resource);
 		if (drain && readOnly) {
 			throw new Error(`Error while writing resource ${resource.getPath()}: ` +
 				"Do not use options 'drain' and 'readOnly' at the same time.");
 		}
 
-		const relPath = resource.getPath().substr(this._virBasePath.length);
-		const fsPath = path.join(this._fsBasePath, relPath);
+		const relPath = this._resolveVirtualPathToBase(resource.getPath(), true);
+		const fsPath = this._resolveToFileSystem(relPath);
 		const dirPath = path.dirname(fsPath);
 
 		await mkdir(dirPath, {recursive: true});
@@ -334,6 +349,20 @@ class FileSystem extends AbstractAdapter {
 				return fs.createReadStream(fsPath);
 			});
 		}
+	}
+
+	_resolveToFileSystem(relPath) {
+		const fsPath = path.join(this._fsBasePath, relPath);
+
+		if (!fsPath.startsWith(this._fsBasePath)) {
+			log.verbose(`Failed to resolve virtual path internally: ${relPath}`);
+			log.verbose(`  Adapter base path: ${this._fsBasePath}`);
+			log.verbose(`  Resulting path: ${fsPath}`);
+			throw new Error(
+				`Error while resolving internal virtual path: '${relPath}' resolves ` +
+				`to a directory not accessible by this File System adapter instance`);
+		}
+		return fsPath;
 	}
 }
 

--- a/lib/adapters/Memory.js
+++ b/lib/adapters/Memory.js
@@ -19,7 +19,8 @@ class Memory extends AbstractAdapter {
 	 *
 	 * @public
 	 * @param {object} parameters Parameters
-	 * @param {string} parameters.virBasePath Virtual base path
+	 * @param {string} parameters.virBasePath
+	 *   Virtual base path. Must be absolute, POSIX-style, and must end with a slash
 	 * @param {string[]} [parameters.excludes] List of glob patterns to exclude
 	 * @param {@ui5/project/specifications/Project} [parameters.project] Project this adapter belongs to (if any)
 	 */
@@ -106,15 +107,11 @@ class Memory extends AbstractAdapter {
 	 * @returns {Promise<@ui5/fs/Resource>} Promise resolving to a single resource
 	 */
 	async _byPath(virPath, options, trace) {
-		if (this.isPathExcluded(virPath)) {
-			return null;
-		}
-		if (!virPath.startsWith(this._virBasePath) && virPath !== this._virBaseDir) {
-			// Neither starts with basePath, nor equals baseDirectory
+		const relPath = this._resolveVirtualPathToBase(virPath);
+		if (!relPath) {
 			return null;
 		}
 
-		const relPath = virPath.substr(this._virBasePath.length);
 		trace.pathCall();
 
 		const resource = this._virFiles[relPath];
@@ -140,8 +137,8 @@ class Memory extends AbstractAdapter {
 			// Otherwise await would automatically create a Promise, causing unwanted overhead
 			resource = await resource;
 		}
-		super._write(resource);
-		const relPath = resource.getPath().substr(this._virBasePath.length);
+		this._assignProjectToResource(resource);
+		const relPath = this._resolveVirtualPathToBase(resource.getPath(), true);
 		log.silly(`Writing to virtual path ${resource.getPath()}`);
 		this._virFiles[relPath] = await resource.clone();
 

--- a/lib/resourceFactory.js
+++ b/lib/resourceFactory.js
@@ -1,7 +1,7 @@
 import path from "node:path";
 import minimatch from "minimatch";
 import DuplexCollection from "./DuplexCollection.js";
-import FileSystem from "./adapters/FileSystem.js";
+import FsAdapter from "./adapters/FileSystem.js";
 import MemAdapter from "./adapters/Memory.js";
 import ReaderCollection from "./ReaderCollection.js";
 import ReaderCollectionPrioritized from "./ReaderCollectionPrioritized.js";
@@ -24,8 +24,11 @@ import Link from "./readers/Link.js";
  *
  * @public
  * @param {object} parameters Parameters
- * @param {string} parameters.virBasePath Virtual base path
- * @param {string} [parameters.fsBasePath] File system base path
+ * @param {string} parameters.virBasePath Virtual base path. Must be absolute, POSIX-style, and must end with a slash
+ * @param {string} [parameters.fsBasePath]
+ *   File System base path.
+ *   If this parameter is supplied, a File System adapter will be created instead of a Memory adapter.
+ *   The provided path must be absolute and must use platform-specific path segment separators.
  * @param {string[]} [parameters.excludes] List of glob patterns to exclude
  * @param {object} [parameters.useGitignore=false]
  *   Whether to apply any excludes defined in an optional .gitignore in the base directory.
@@ -35,7 +38,6 @@ import Link from "./readers/Link.js";
  */
 export function createAdapter({fsBasePath, virBasePath, project, excludes, useGitignore}) {
 	if (fsBasePath) {
-		const FsAdapter = FileSystem;
 		return new FsAdapter({fsBasePath, virBasePath, project, excludes, useGitignore});
 	} else {
 		return new MemAdapter({virBasePath, project, excludes});
@@ -43,12 +45,13 @@ export function createAdapter({fsBasePath, virBasePath, project, excludes, useGi
 }
 
 /**
- * Creates an adapter and wraps it in a ReaderCollection
+ * Creates a File System adapter and wraps it in a ReaderCollection
  *
  * @public
  * @param {object} parameters Parameters
- * @param {string} parameters.virBasePath Virtual base path
- * @param {string} parameters.fsBasePath File system base path
+ * @param {string} parameters.virBasePath Virtual base path. Must be absolute, POSIX-style, and must end with a slash
+ * @param {string} parameters.fsBasePath
+ *   File System base path. Must be absolute and must use platform-specific path segment separators
  * @param {object} [parameters.project] Experimental, internal parameter. Do not use
  * @param {string[]} [parameters.excludes] List of glob patterns to exclude
  * @param {string} [parameters.name] Name for the reader collection
@@ -61,7 +64,7 @@ export function createReader({fsBasePath, virBasePath, project, excludes = [], n
 	if (!fsBasePath) {
 		// Creating a reader with a memory adapter seems pointless right now
 		// since there would be no way to fill the adapter with resources
-		throw new Error(`Missing parameter "fsBasePath"`);
+		throw new Error(`Unable to create reader: Missing parameter "fsBasePath"`);
 	}
 	return new ReaderCollection({
 		name,
@@ -148,11 +151,11 @@ export function createResource(parameters) {
  * @param {@ui5/fs/AbstractReader} parameters.reader Single reader or collection of readers
  * @param {@ui5/fs/AbstractReaderWriter} [parameters.writer] A ReaderWriter instance which is
  *        only used for writing files. If not supplied, a Memory adapter will be created.
- * @param {string} [parameters.name="vir & fs source"] Name of the collection
+ * @param {string} [parameters.name="workspace"] Name of the collection
  * @param {string} [parameters.virBasePath="/"] Virtual base path
  * @returns {@ui5/fs/DuplexCollection} DuplexCollection which wraps the provided resource locators
  */
-export function createWorkspace({reader, writer, virBasePath = "/", name = "vir & fs source"}) {
+export function createWorkspace({reader, writer, virBasePath = "/", name = "workspace"}) {
 	if (!writer) {
 		writer = new MemAdapter({
 			virBasePath

--- a/test/lib/DuplexCollection.js
+++ b/test/lib/DuplexCollection.js
@@ -59,7 +59,7 @@ test("DuplexCollection: _byGlob", async (t) => {
 	t.plan(5);
 
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const abstractReader = {
@@ -79,7 +79,7 @@ test("DuplexCollection: _byGlob", async (t) => {
 
 	t.true(Array.isArray(resources), "Found resources are returned as an array");
 	t.true(resources.length === 1, "Resource found");
-	t.is(resource.getPath(), "my/path", "Resource has expected path");
+	t.is(resource.getPath(), "/my/path", "Resource has expected path");
 	t.true(comboSpy.calledWithExactly("anyPattern", {someOption: true}, trace),
 		"Delegated globbing task correctly to readers");
 	t.is(resourceContent, "content", "Resource has expected content");
@@ -108,7 +108,7 @@ test("DuplexCollection: _byGlobSource with default options and a reader finding 
 	t.plan(3);
 
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const abstractReader = {
@@ -127,7 +127,7 @@ test("DuplexCollection: _byGlobSource with default options and a reader finding 
 	t.true(Array.isArray(resources), "Found resources are returned as an array");
 	t.true(abstractReader.byGlob.calledWithExactly("anyPattern", {nodir: true}),
 		"Delegated globbing task correctly to readers");
-	t.true(abstractWriter.byPath.calledWithExactly("my/path"),
+	t.true(abstractWriter.byPath.calledWithExactly("/my/path"),
 		"byPath called on writer");
 });
 
@@ -135,7 +135,7 @@ test("DuplexCollection: _byPath with reader finding a resource", async (t) => {
 	t.plan(4);
 
 	const resource = new Resource({
-		path: "path",
+		path: "/path",
 		buffer: Buffer.from("content")
 	});
 	const pushCollectionSpy = sinon.spy(resource, "pushCollection");
@@ -157,7 +157,7 @@ test("DuplexCollection: _byPath with reader finding a resource", async (t) => {
 	t.true(comboSpy.calledWithExactly("anyVirtualPath", {someOption: true}, trace),
 		"Delegated globbing task correctly to readers");
 	t.true(pushCollectionSpy.called, "pushCollection called on resource");
-	t.is(readResource.getPath(), "path", "Resource has expected path");
+	t.is(readResource.getPath(), "/path", "Resource has expected path");
 	t.is(readResourceContent, "content", "Resource has expected content");
 });
 
@@ -191,7 +191,7 @@ test("DuplexCollection: _write successful", async (t) => {
 	t.plan(1);
 
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const duplexCollection = new DuplexCollection({

--- a/test/lib/ReaderCollection.js
+++ b/test/lib/ReaderCollection.js
@@ -39,7 +39,7 @@ test("ReaderCollection: _byGlob with finding a resource", async (t) => {
 	t.plan(6);
 
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const abstractReader = {
@@ -61,7 +61,7 @@ test("ReaderCollection: _byGlob with finding a resource", async (t) => {
 	t.true(abstractReader._byGlob.calledWithExactly("anyPattern", {someOption: true}, trace),
 		"Delegated globbing task correctly to readers");
 	t.true(trace.collection.called, "Trace.collection called");
-	t.is(resources[0].getPath(), "my/path", "Resource has expected path");
+	t.is(resources[0].getPath(), "/my/path", "Resource has expected path");
 	t.is(resourceContent, "content", "Resource has expected content");
 });
 
@@ -69,7 +69,7 @@ test("ReaderCollection: _byPath with reader finding a resource", async (t) => {
 	t.plan(5);
 
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const pushCollectionSpy = sinon.spy(resource, "pushCollection");
@@ -91,7 +91,7 @@ test("ReaderCollection: _byPath with reader finding a resource", async (t) => {
 		"Delegated globbing task correctly to readers");
 	t.true(trace.collection.called, "Trace.collection called");
 	t.true(pushCollectionSpy.called, "pushCollection called on resource");
-	t.is(readResource.getPath(), "my/path", "Resource has expected path");
+	t.is(readResource.getPath(), "/my/path", "Resource has expected path");
 	t.is(readResourceContent, "content", "Resource has expected content");
 });
 
@@ -137,7 +137,7 @@ test("ReaderCollection: _byPath with empty readers array", async (t) => {
 
 test("ReaderCollection: _byPath with some empty readers", async (t) => {
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const abstractReaderOne = {
@@ -174,7 +174,7 @@ test("ReaderCollection: _byGlob with empty readers array", async (t) => {
 
 test("ReaderCollection: _byGlob with some empty readers", async (t) => {
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const abstractReaderOne = {

--- a/test/lib/ReaderCollectionPrioritized.js
+++ b/test/lib/ReaderCollectionPrioritized.js
@@ -35,7 +35,7 @@ test("ReaderCollectionPrioritized: _byGlob w/o finding a resource", async (t) =>
 
 test("ReaderCollectionPrioritized: _byGlob with finding a resource", async (t) => {
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const abstractReader = {
@@ -57,13 +57,13 @@ test("ReaderCollectionPrioritized: _byGlob with finding a resource", async (t) =
 	t.true(abstractReader._byGlob.calledWithExactly("anyPattern", {someOption: true}, trace),
 		"Delegated globbing task correctly to readers");
 	t.true(trace.collection.called, "Trace.collection called");
-	t.is(resources[0].getPath(), "my/path", "Resource has expected path");
+	t.is(resources[0].getPath(), "/my/path", "Resource has expected path");
 	t.is(resourceContent, "content", "Resource has expected content");
 });
 
 test("ReaderCollectionPrioritized: _byPath with reader finding a resource", async (t) => {
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const pushCollectionSpy = sinon.spy(resource, "pushCollection");
@@ -84,7 +84,7 @@ test("ReaderCollectionPrioritized: _byPath with reader finding a resource", asyn
 	t.true(abstractReader._byPath.calledWithExactly("anyVirtualPath", {someOption: true}, trace),
 		"Delegated globbing task correctly to readers");
 	t.true(pushCollectionSpy.called, "pushCollection called on resource");
-	t.is(readResource.getPath(), "my/path", "Resource has expected path");
+	t.is(readResource.getPath(), "/my/path", "Resource has expected path");
 	t.is(readResourceContent, "content", "Resource has expected content");
 });
 
@@ -127,7 +127,7 @@ test("ReaderCollectionPrioritized: _byPath with empty readers array", async (t) 
 
 test("ReaderCollectionPrioritized: _byPath with some empty readers", async (t) => {
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const abstractReaderOne = {
@@ -164,7 +164,7 @@ test("ReaderCollectionPrioritized: _byGlob with empty readers array", async (t) 
 
 test("ReaderCollectionPrioritized: _byGlob with some empty readers", async (t) => {
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("content")
 	});
 	const abstractReaderOne = {

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -44,38 +44,38 @@ test("Resource: constructor with missing path parameter", (t) => {
 		new Resource({});
 	}, {
 		instanceOf: Error,
-		message: "Cannot create Resource: path parameter missing"
+		message: "Unable to create Resource: Missing parameter 'path'"
 	});
 });
 
 test("Resource: constructor with duplicated content parameter", (t) => {
 	const fsPath = path.join("test", "fixtures", "application.a", "webapp", "index.html");
 	[{
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("Content"),
 		string: "Content",
 	}, {
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("Content"),
 		stream: createReadStream(fsPath),
 	}, {
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("Content"),
 		createStream: () => {
 			return createReadStream(fsPath);
 		},
 	}, {
-		path: "my/path",
+		path: "/my/path",
 		string: "Content",
 		stream: createReadStream(fsPath),
 	}, {
-		path: "my/path",
+		path: "/my/path",
 		string: "Content",
 		createStream: () => {
 			return createReadStream(fsPath);
 		},
 	}, {
-		path: "my/path",
+		path: "/my/path",
 		stream: createReadStream(fsPath),
 		createStream: () => {
 			return createReadStream(fsPath);
@@ -85,15 +85,15 @@ test("Resource: constructor with duplicated content parameter", (t) => {
 			new Resource(resourceParams);
 		}, {
 			instanceOf: Error,
-			message: "Cannot create Resource: Please set only one content parameter. " +
-				"Buffer, string, stream or createStream"
+			message: "Unable to create Resource: Please set only one content parameter. " +
+				"'buffer', 'string', 'stream' or 'createStream'"
 		}, "Threw with expected error message");
 	});
 });
 
 test("Resource: From buffer", async (t) => {
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		buffer: Buffer.from("Content"),
 		sourceMetadata: {}
 	});
@@ -104,7 +104,7 @@ test("Resource: From buffer", async (t) => {
 
 test("Resource: From string", async (t) => {
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		string: "Content",
 		sourceMetadata: {}
 	});
@@ -116,7 +116,7 @@ test("Resource: From string", async (t) => {
 test("Resource: From stream", async (t) => {
 	const fsPath = path.join("test", "fixtures", "application.a", "webapp", "index.html");
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		stream: createReadStream(fsPath),
 		sourceMetadata: {}
 	});
@@ -128,7 +128,7 @@ test("Resource: From stream", async (t) => {
 test("Resource: From createStream", async (t) => {
 	const fsPath = path.join("test", "fixtures", "application.a", "webapp", "index.html");
 	const resource = new Resource({
-		path: "my/path",
+		path: "/my/path",
 		createStream: () => {
 			return createReadStream(fsPath);
 		},
@@ -143,39 +143,64 @@ test("Resource: getBuffer with throwing an error", (t) => {
 	t.plan(1);
 
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 	});
 
 	return resource.getBuffer().catch(function(error) {
-		t.is(error.message, "Resource my/path/to/resource has no content",
+		t.is(error.message, "Resource /my/path/to/resource has no content",
 			"getBuffer called w/o having a resource content provided");
 	});
 });
 
 test("Resource: getPath / getName", (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource.js",
+		path: "/my/path/to/resource.js",
 		buffer: Buffer.from("Content")
 	});
-	t.is(resource.getPath(), "my/path/to/resource.js", "Correct path");
+	t.is(resource.getPath(), "/my/path/to/resource.js", "Correct path");
 	t.is(resource.getName(), "resource.js", "Correct name");
 });
 
 test("Resource: setPath / getName", (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource.js",
+		path: "/my/path/to/resource.js",
 		buffer: Buffer.from("Content")
 	});
-	resource.setPath("my/other/file.json");
-	t.is(resource.getPath(), "my/other/file.json", "Correct path");
+	resource.setPath("/my/other/file.json");
+	t.is(resource.getPath(), "/my/other/file.json", "Correct path");
 	t.is(resource.getName(), "file.json", "Correct name");
+});
+
+test("Resource: setPath with non-absolute path", (t) => {
+	const resource = new Resource({
+		path: "/my/path/to/resource.js",
+		buffer: Buffer.from("Content")
+	});
+	t.throws(() => {
+		resource.setPath("my/other/file.json");
+	}, {
+		message: "Unable to set resource path: Path must be absolute: my/other/file.json"
+	}, "Threw with expected error message");
+	t.is(resource.getPath(), "/my/path/to/resource.js", "Path is unchanged");
+	t.is(resource.getName(), "resource.js", "Name is unchanged");
+});
+
+test("Create Resource with non-absolute path", (t) => {
+	t.throws(() => {
+		new Resource({
+			path: "my/path/to/resource.js",
+			buffer: Buffer.from("Content")
+		});
+	}, {
+		message: "Unable to set resource path: Path must be absolute: my/path/to/resource.js"
+	}, "Threw with expected error message");
 });
 
 test("Resource: getStream", async (t) => {
 	t.plan(1);
 
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		buffer: Buffer.from("Content")
 	});
 
@@ -187,7 +212,7 @@ test("Resource: getStream for empty string", async (t) => {
 	t.plan(1);
 
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		string: ""
 	});
 
@@ -199,7 +224,7 @@ test("Resource: getStream for empty string instance", async (t) => {
 	t.plan(1);
 
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		// eslint-disable-next-line no-new-wrappers
 		string: new String("")
 	});
@@ -210,20 +235,20 @@ test("Resource: getStream for empty string instance", async (t) => {
 
 test("Resource: getStream throwing an error", (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource"
+		path: "/my/path/to/resource"
 	});
 
 	t.throws(() => {
 		resource.getStream();
 	}, {
 		instanceOf: Error,
-		message: "Resource my/path/to/resource has no content"
+		message: "Resource /my/path/to/resource has no content"
 	});
 });
 
 test("Resource: setString", async (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		sourceMetadata: {} // Needs to be passed in order to get the "modified" state
 	});
 
@@ -241,7 +266,7 @@ test("Resource: setString", async (t) => {
 
 test("Resource: setBuffer", async (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		sourceMetadata: {} // Needs to be passed in order to get the "modified" state
 	});
 
@@ -259,7 +284,7 @@ test("Resource: setBuffer", async (t) => {
 
 test("Resource: size modification", async (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource"
+		path: "/my/path/to/resource"
 	});
 	t.is(await resource.getSize(), 0, "initial size without content");
 
@@ -268,7 +293,7 @@ test("Resource: size modification", async (t) => {
 
 	t.is(await resource.getSize(), 7, "size after manually setting the string");
 	t.is(await new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		string: "Content"
 	}).getSize(), 7, "size when passing string to constructor");
 
@@ -287,7 +312,7 @@ test("Resource: size modification", async (t) => {
 
 	t.is(await resource.getSize(), 1234, "buffer with alloc after setting the buffer");
 	t.is(await new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		buffer: buf
 	}).getSize(), 1234, "buffer with alloc when passing buffer to constructor");
 
@@ -296,7 +321,7 @@ test("Resource: size modification", async (t) => {
 
 	// stream
 	const streamResource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 	});
 	const stream = new Stream.Readable();
 	stream._read = function() {};
@@ -317,7 +342,7 @@ test("Resource: size modification", async (t) => {
 
 test("Resource: setStream (Stream)", async (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		sourceMetadata: {} // Needs to be passed in order to get the "modified" state
 	});
 
@@ -342,7 +367,7 @@ test("Resource: setStream (Stream)", async (t) => {
 
 test("Resource: setStream (Create stream callback)", async (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		sourceMetadata: {} // Needs to be passed in order to get the "modified" state
 	});
 
@@ -370,7 +395,7 @@ test("Resource: clone resource with buffer", async (t) => {
 	t.plan(2);
 
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		buffer: Buffer.from("Content")
 	});
 
@@ -385,7 +410,7 @@ test("Resource: clone resource with stream", async (t) => {
 	t.plan(2);
 
 	const resource = new Resource({
-		path: "my/path/to/resource"
+		path: "/my/path/to/resource"
 	});
 	const stream = new Stream.Readable();
 	stream._read = function() {};
@@ -403,7 +428,7 @@ test("Resource: clone resource with stream", async (t) => {
 
 test("Resource: clone resource with sourceMetadata", async (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		sourceMetadata: {
 			adapter: "FileSystem",
 			fsPath: "/resources/my.js"
@@ -444,7 +469,7 @@ test("Resource: clone resource with project removes project", async (t) => {
 	};
 
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		project: myProject
 	});
 
@@ -457,7 +482,7 @@ test("Resource: clone resource with project removes project", async (t) => {
 
 test("Resource: create resource with sourceMetadata.contentModified: true", (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		sourceMetadata: {
 			adapter: "FileSystem",
 			fsPath: "/resources/my.js",
@@ -539,7 +564,7 @@ test("getBuffer from Stream content: Subsequent content requests should not thro
 test("Resource: getProject", (t) => {
 	t.plan(1);
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		project: {getName: () => "Mock Project"}
 	});
 	const project = resource.getProject();
@@ -549,7 +574,7 @@ test("Resource: getProject", (t) => {
 test("Resource: setProject", (t) => {
 	t.plan(1);
 	const resource = new Resource({
-		path: "my/path/to/resource"
+		path: "/my/path/to/resource"
 	});
 	const project = {getName: () => "Mock Project"};
 	resource.setProject(project);
@@ -559,12 +584,12 @@ test("Resource: setProject", (t) => {
 test("Resource: reassign with setProject", (t) => {
 	t.plan(2);
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		project: {getName: () => "Mock Project"}
 	});
 	const project = {getName: () => "New Mock Project"};
 	const error = t.throws(() => resource.setProject(project));
-	t.is(error.message, "Unable to assign project New Mock Project to resource my/path/to/resource: " +
+	t.is(error.message, "Unable to assign project New Mock Project to resource /my/path/to/resource: " +
 		"Resource is already associated to project " + project);
 });
 
@@ -577,7 +602,7 @@ test("Resource: constructor with stream", async (t) => {
 	stream.push(null);
 
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		stream,
 		sourceMetadata: {} // Needs to be passed in order to get the "modified" state
 	});
@@ -596,7 +621,7 @@ test("integration stat - resource size", async (t) => {
 	const statInfo = await fs.stat(fsPath);
 
 	const resource = new Resource({
-		path: fsPath,
+		path: "/some/path",
 		statInfo,
 		createStream: () => {
 			return createReadStream(fsPath);

--- a/test/lib/ResourceFacade.js
+++ b/test/lib/ResourceFacade.js
@@ -9,14 +9,14 @@ test.afterEach.always( (t) => {
 
 test("Create instance", (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		string: "my content"
 	});
 	const resourceFacade = new ResourceFacade({
-		path: "my/path",
+		path: "/my/path",
 		resource
 	});
-	t.is(resourceFacade.getPath(), "my/path", "Returns correct path");
+	t.is(resourceFacade.getPath(), "/my/path", "Returns correct path");
 	t.is(resourceFacade.getName(), "path", "Returns correct name");
 	t.is(resourceFacade.getConcealedResource(), resource, "Returns correct concealed resource");
 });
@@ -24,11 +24,11 @@ test("Create instance", (t) => {
 test("Create instance: Missing parameters", (t) => {
 	t.throws(() => {
 		new ResourceFacade({
-			path: "my/path",
+			path: "/my/path",
 		});
 	}, {
 		instanceOf: Error,
-		message: "Cannot create ResourceFacade: resource parameter missing"
+		message: "Unable to create ResourceFacade: Missing parameter 'resource'"
 	});
 	t.throws(() => {
 		new ResourceFacade({
@@ -36,32 +36,32 @@ test("Create instance: Missing parameters", (t) => {
 		});
 	}, {
 		instanceOf: Error,
-		message: "Cannot create ResourceFacade: path parameter missing"
+		message: "Unable to create ResourceFacade: Missing parameter 'path'"
 	});
 });
 
 test("ResourceFacade #clone", async (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		string: "my content"
 	});
 	const resourceFacade = new ResourceFacade({
-		path: "my/path",
+		path: "/my/path",
 		resource
 	});
 
 	const clone = await resourceFacade.clone();
 	t.true(clone instanceof Resource, "Cloned resource facade is an instance of Resource");
-	t.is(clone.getPath(), "my/path", "Cloned resource has path of resource facade");
+	t.is(clone.getPath(), "/my/path", "Cloned resource has path of resource facade");
 });
 
 test("ResourceFacade #setPath", (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		string: "my content"
 	});
 	const resourceFacade = new ResourceFacade({
-		path: "my/path",
+		path: "/my/path",
 		resource
 	});
 
@@ -73,11 +73,11 @@ test("ResourceFacade #setPath", (t) => {
 
 test("ResourceFacade provides same public functions as Resource", (t) => {
 	const resource = new Resource({
-		path: "my/path/to/resource",
+		path: "/my/path/to/resource",
 		string: "my content"
 	});
 	const resourceFacade = new ResourceFacade({
-		path: "my/path",
+		path: "/my/path",
 		resource
 	});
 

--- a/test/lib/adapters/FileSystem.js
+++ b/test/lib/adapters/FileSystem.js
@@ -1,0 +1,13 @@
+import test from "ava";
+
+import FileSystem from "../../../lib/adapters/FileSystem.js";
+
+test.serial("Missing parameter: fsBasePath", (t) => {
+	t.throws(() => {
+		new FileSystem({
+			virBasePath: "/"
+		});
+	}, {
+		message: "Unable to create adapter: Missing parameter 'fsBasePath'"
+	}, "Threw with expected error message");
+});

--- a/test/lib/adapters/FileSystem_read.js
+++ b/test/lib/adapters/FileSystem_read.js
@@ -101,7 +101,20 @@ test("glob resources from application.a with directory exclude", async (t) => {
 	});
 });
 
-test("byPath virtual directory", async (t) => {
+test("glob virtual directory above virtual base path (path traversal)", async (t) => {
+	const readerWriter = createAdapter({
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/app/"
+	});
+
+	const res = await readerWriter.byGlob([
+		"/*/../*",
+	], {nodir: false});
+	t.is(res.length, 0, "Returned no resources");
+});
+
+
+test("byPath", async (t) => {
 	const readerWriter = createAdapter({
 		fsBasePath: "./test/fixtures/application.a/webapp",
 		virBasePath: "/resources/app/"
@@ -109,6 +122,16 @@ test("byPath virtual directory", async (t) => {
 
 	const resource = await readerWriter.byPath("/resources/app/index.html", {nodir: true});
 	t.truthy(resource, "Found one resource");
+});
+
+test("byPath virtual directory above base path (path traversal)", async (t) => {
+	const readerWriter = createAdapter({
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/resources/app/"
+	});
+
+	const resource = await readerWriter.byPath("/resources/app/../package.json", {nodir: true});
+	t.is(resource, null, "Found no resource");
 });
 
 function getPathFromResource(resource) {
@@ -445,7 +468,7 @@ test("byPath with useGitignore: true", async (t) => {
 	t.is(isGitIgnoredSpy.callCount, 1);
 	t.deepEqual(
 		isGitIgnoredSpy.getCall(0).args,
-		[{cwd: path.resolve(fsBasePath)}],
+		[{cwd: path.resolve(fsBasePath) + path.sep}],
 		"isGitIgnored should be called with the correct cwd"
 	);
 

--- a/test/lib/adapters/Memory_read.js
+++ b/test/lib/adapters/Memory_read.js
@@ -257,6 +257,48 @@ test("glob subdirectory", async (t) => {
 	t.is(resources[0].getStatInfo().isDirectory(), true);
 });
 
+test("glob virtual directory above virtual base path (path traversal)", async (t) => {
+	const readerWriter = createAdapter({
+		virBasePath: "/resources/app/"
+	});
+	await fillFromFs(readerWriter, {
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/resources/app/",
+	});
+
+	const res = await readerWriter.byGlob([
+		"/*/../*",
+	], {nodir: false});
+	t.is(res.length, 0, "Returned no resources");
+});
+
+test("byPath", async (t) => {
+	const readerWriter = createAdapter({
+		virBasePath: "/resources/app/"
+	});
+	await fillFromFs(readerWriter, {
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/resources/app/",
+	});
+
+	const resource = await readerWriter.byPath("/resources/app/index.html", {nodir: true});
+	t.truthy(resource, "Found one resource");
+});
+
+test("byPath virtual directory above base path (path traversal)", async (t) => {
+	const readerWriter = createAdapter({
+		virBasePath: "/resources/app/"
+	});
+	await fillFromFs(readerWriter, {
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/resources/app/",
+	});
+
+	const resource = await readerWriter.byPath("/resources/app/../package.json", {nodir: true});
+	t.is(resource, null, "Found no resource");
+});
+
+
 function getPathFromResource(resource) {
 	return resource.getPath();
 }

--- a/test/lib/resourceFactory.js
+++ b/test/lib/resourceFactory.js
@@ -116,7 +116,7 @@ test("createReader: Throw error missing 'fsBasePath'", (t) => {
 		excludes: ["**/*.html"],
 		name: "reader name"
 	}));
-	t.is(error.message, "Missing parameter \"fsBasePath\"");
+	t.is(error.message, "Unable to create reader: Missing parameter \"fsBasePath\"");
 });
 
 test("createReaderCollection", async (t) => {


### PR DESCRIPTION
* Resources: Resources must always have absolute paths. This was already the case in the past but is now properly validated. Resources with relative paths could lead to undetermined behavior.

* Adapters: Improve checks to make sure that resolved paths still start with the adapter base path. This should prevent path traversals outside the adapter's base path.