### PR TITLE
[INTERNAL] Adapters: Fix if-clause checking for matching base path

### DIFF
--- a/lib/adapters/FileSystem.js
+++ b/lib/adapters/FileSystem.js
@@ -105,7 +105,7 @@ class FileSystem extends AbstractAdapter {
 				promises.push(new Promise((resolve, reject) => {
 					const virPath = (this._virBasePath + matches[i]);
 					const relPath = this._resolveVirtualPathToBase(virPath);
-					if (!relPath) {
+					if (relPath === null) {
 						// Match is likely outside adapter base path
 						log.verbose(
 							`Failed to resolve virtual path of glob match '${virPath}': Path must start with ` +
@@ -154,9 +154,11 @@ class FileSystem extends AbstractAdapter {
 	async _byPath(virPath, options, trace) {
 		const relPath = this._resolveVirtualPathToBase(virPath);
 
-		if (!relPath) {
+		if (relPath === null) {
 			// Neither starts with basePath, nor equals baseDirectory
 			if (!options.nodir && this._virBasePath.startsWith(virPath)) {
+				// Create virtual directories for the virtual base path (which has to exist)
+				// TODO: Maybe improve this by actually matching the base paths segments to the virPath
 				return this._createResource({
 					project: this._project,
 					statInfo: { // TODO: make closer to fs stat info

--- a/lib/adapters/Memory.js
+++ b/lib/adapters/Memory.js
@@ -108,7 +108,7 @@ class Memory extends AbstractAdapter {
 	 */
 	async _byPath(virPath, options, trace) {
 		const relPath = this._resolveVirtualPathToBase(virPath);
-		if (!relPath) {
+		if (relPath === null) {
 			return null;
 		}
 

--- a/test/lib/adapters/FileSystem_read.js
+++ b/test/lib/adapters/FileSystem_read.js
@@ -113,7 +113,6 @@ test("glob virtual directory above virtual base path (path traversal)", async (t
 	t.is(res.length, 0, "Returned no resources");
 });
 
-
 test("byPath", async (t) => {
 	const readerWriter = createAdapter({
 		fsBasePath: "./test/fixtures/application.a/webapp",
@@ -132,6 +131,59 @@ test("byPath virtual directory above base path (path traversal)", async (t) => {
 
 	const resource = await readerWriter.byPath("/resources/app/../package.json", {nodir: true});
 	t.is(resource, null, "Found no resource");
+});
+
+test("byPath: Root dir w/ trailing slash", async (t) => {
+	const readerWriter = createAdapter({
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/resources/app/"
+	});
+
+	const resource = await readerWriter.byPath("/resources/app/", {nodir: false});
+	t.truthy(resource, "Found one resource");
+});
+
+test("byPath: Root dir w/o trailing slash", async (t) => {
+	const readerWriter = createAdapter({
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/resources/app/"
+	});
+
+	const resource = await readerWriter.byPath("/resources/app", {nodir: false});
+	t.truthy(resource, "Found one resource");
+});
+
+test("byPath: Virtual directory w/ trailing slash", async (t) => {
+	const readerWriter = createAdapter({
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/resources/app/"
+	});
+
+	const resource = await readerWriter.byPath("/resources/", {nodir: false});
+	t.truthy(resource, "Found one resource");
+});
+
+test("byPath: Virtual directory w/o trailing slash", async (t) => {
+	const readerWriter = createAdapter({
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/resources/app/"
+	});
+
+	const resource = await readerWriter.byPath("/resources", {nodir: false});
+	t.truthy(resource, "Found one resource");
+});
+
+test("byPath: Incorrect virtual directory w/o trailing slash", async (t) => {
+	// Adding a trailing slash would make the path not match the base path, which is already
+	// tested elsewhere
+	const readerWriter = createAdapter({
+		fsBasePath: "./test/fixtures/application.a/webapp",
+		virBasePath: "/resources/app/"
+	});
+
+	// TODO: This should actually not match
+	const resource = await readerWriter.byPath("/resour", {nodir: false});
+	t.truthy(resource, "Found one resource");
 });
 
 function getPathFromResource(resource) {


### PR DESCRIPTION
AbstractAdapter#_resolveVirtualPathToBase might return an empty string
in case the root path of the adapter is matched. Therefore, adapters
must only reject the path if the method returned 'null'.