### PR TITLE
[INTERNAL] eslint: set jsdoc mode to 'jsdoc' instead of new default 'typescript'

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -75,6 +75,7 @@ module.exports = {
 	},
 	"settings": {
 		"jsdoc": {
+			"mode": "jsdoc",
 			"tagNamePreference": {
 				"return": "returns",
 				"augments": "extends"


### PR DESCRIPTION
Set the eslint/jsdoc mode manually to `jsdoc`. With https://github.com/gajus/eslint-plugin-jsdoc/releases/tag/v44.0.0 it was changed to `typescript`.