### PR TITLE
[BREAKING] Require Node.js 20.11.x/>=21.2.0 and npm >=10

### DIFF
--- a/.github/workflows/github-ci.yml
+++ b/.github/workflows/github-ci.yml
@@ -16,10 +16,10 @@ jobs:
 
     - uses: actions/checkout@v4
 
-    - name: Use Node.js LTS 16.18.0
+    - name: Use Node.js LTS 20.11.0
       uses: actions/setup-node@v4.0.2
       with:
-        node-version: 16.18.0
+        node-version: 20.11.0
 
     - name: Install dependencies
       run: npm ci

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,32 +6,35 @@
 trigger:
 - main
 
+variables:
+  CI: true
+
 strategy:
   matrix:
-    linux_node_lts_16:
+    linux_node_lts_20_min_version:
       imageName: 'ubuntu-22.04'
-      node_version: 16.x
-    linux_node_lts_18_min_version:
+      node_version: 20.11.0
+    linux_node_21_min_version:
       imageName: 'ubuntu-22.04'
-      node_version: 18.12.0
-    linux_node_lts_18:
+      node_version: 21.2.0
+    linux_node_lts_20:
       imageName: 'ubuntu-22.04'
-      node_version: 18.x
-    mac_node_lts_18:
+      node_version: 20.x
+    mac_node_lts_20:
       imageName: 'macos-12'
-      node_version: 18.x
-    windows_node_lts_18:
+      node_version: 20.x
+    windows_node_lts_20:
       imageName: 'windows-2022'
-      node_version: 18.x
+      node_version: 20.x
     linux_node_current:
       imageName: 'ubuntu-22.04'
-      node_version: 20.x
+      node_version: 21.x
     mac_node_current:
       imageName: 'macos-12'
-      node_version: 20.x
+      node_version: 21.x
     windows_node_current:
       imageName: 'windows-2022'
-      node_version: 20.x
+      node_version: 21.x
 
 pool:
   vmImage: $(imageName)

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,8 +41,8 @@
 				"tap-xunit": "^2.4.1"
 			},
 			"engines": {
-				"node": "^16.18.0 || >=18.12.0",
-				"npm": ">= 8"
+				"node": "^20.11.0 || >=21.2.0",
+				"npm": ">= 10"
 			}
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
 		"./internal/ResourceTagCollection": "./lib/ResourceTagCollection.js"
 	},
 	"engines": {
-		"node": "^16.18.0 || >=18.12.0",
-		"npm": ">= 8"
+		"node": "^20.11.0 || >=21.2.0",
+		"npm": ">= 10"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run depcheck",

--- a/test/lib/package-exports.js
+++ b/test/lib/package-exports.js
@@ -1,7 +1,7 @@
 import test from "ava";
 import {createRequire} from "node:module";
 
-// Using CommonsJS require as importing json files causes an ExperimentalWarning
+// Using CommonsJS require since JSON module imports are still experimental
 const require = createRequire(import.meta.url);
 
 // package.json should be exported to allow reading version (e.g. from @ui5/cli)


### PR DESCRIPTION
BREAKING CHANGE:
Support for older Node.js and npm releases has been dropped.
Only Node.js 20.11.x and >=21.2.0 as well as npm v10 or higher are supported.

JIRA: CPOUI5FOUNDATION-800