### PR TITLE
[INTERNAL] Refactor tests to get rid of chai and chai-fs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,8 +22,6 @@
 			"devDependencies": {
 				"@istanbuljs/esm-loader-hook": "^0.2.0",
 				"ava": "^6.1.1",
-				"chai": "^4.4.1",
-				"chai-fs": "^2.0.0",
 				"chokidar-cli": "^3.0.0",
 				"cross-env": "^7.0.3",
 				"depcheck": "^1.4.7",
@@ -1219,19 +1217,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/array-events": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/array-events/-/array-events-0.2.0.tgz",
-			"integrity": "sha512-Js6+JM/MxB72WeODWcUOOD/BWRqx6QTff8FWvweERQ0MdzViScUJV4XwRFnXvyvbfhuwWNrwhid7IJe2ux3r4Q==",
-			"dev": true,
-			"dependencies": {
-				"async-arrays": "*",
-				"extended-emitter": "*"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/array-find-index": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -1269,27 +1254,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/assertion-error": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-			"integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/async-arrays": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/async-arrays/-/async-arrays-2.0.0.tgz",
-			"integrity": "sha512-lMm6njQEX7gHbdX/b+PGBDXD/Vwg40BKSatlOaWNxrW/O5wYzARmoh+50h58s3hsyzGPU5+xYndwtc+m91yLiw==",
-			"dev": true,
-			"dependencies": {
-				"sift": "*"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/async-sema": {
@@ -1450,18 +1414,6 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
-		"node_modules/bit-mask": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/bit-mask/-/bit-mask-1.0.2.tgz",
-			"integrity": "sha512-UGtq08LSiazxL4zVmBzrhdCWnT4RWx3JhhD/3crhfv8xxjnVHxf/WoVjEstjSUaZeZRP7kZrWNqup1VvUClCaQ==",
-			"dev": true,
-			"dependencies": {
-				"array-events": "^0.2.0"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/bluebird": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
@@ -1579,12 +1531,6 @@
 				"typedarray-to-buffer": "^3.1.5"
 			}
 		},
-		"node_modules/call-me-maybe": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/call-me-maybe/-/call-me-maybe-1.0.2.tgz",
-			"integrity": "sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==",
-			"dev": true
-		},
 		"node_modules/callsite": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -1659,40 +1605,6 @@
 				"node": ">=16"
 			}
 		},
-		"node_modules/chai": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-			"integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
-			"dev": true,
-			"dependencies": {
-				"assertion-error": "^1.1.0",
-				"check-error": "^1.0.3",
-				"deep-eql": "^4.1.3",
-				"get-func-name": "^2.0.2",
-				"loupe": "^2.3.6",
-				"pathval": "^1.1.1",
-				"type-detect": "^4.0.8"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
-		"node_modules/chai-fs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/chai-fs/-/chai-fs-2.0.0.tgz",
-			"integrity": "sha512-PGfINFH/7XrQBnbp5/MnbFtzBL1//erKs+uoUdyo7KnW0mUX13L6bTO3Jm8OIexSVSh0Y+aaFhhbxyDtb679DA==",
-			"dev": true,
-			"dependencies": {
-				"bit-mask": "^1.0.1",
-				"readdir-enhanced": "^1.4.0"
-			},
-			"engines": {
-				"node": ">=4"
-			},
-			"peerDependencies": {
-				"chai": ">= 1.6.1 < 5"
-			}
-		},
 		"node_modules/chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -1726,18 +1638,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/check-error": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-			"integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
-			"dev": true,
-			"dependencies": {
-				"get-func-name": "^2.0.2"
-			},
-			"engines": {
-				"node": "*"
 			}
 		},
 		"node_modules/chokidar": {
@@ -2351,18 +2251,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/deep-eql": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-			"integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
-			"dev": true,
-			"dependencies": {
-				"type-detect": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=6"
-			}
-		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2712,12 +2600,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
 			"integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==",
-			"dev": true
-		},
-		"node_modules/es6-promise": {
-			"version": "4.2.8",
-			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
-			"integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
 			"dev": true
 		},
 		"node_modules/escalade": {
@@ -3306,18 +3188,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/extended-emitter": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/extended-emitter/-/extended-emitter-1.6.0.tgz",
-			"integrity": "sha512-TNF4xMKL9aKYTR2cTNkKYMUnKzzjfV5Nl6TX45smJ/796CmaFt+KCyidgGdod0Kgj5VSL+ctNIGVf+i1l3e+UA==",
-			"dev": true,
-			"dependencies": {
-				"sift": "*"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3693,15 +3563,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/get-func-name": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
-			"integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/get-package-type": {
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
@@ -3753,12 +3614,6 @@
 			"engines": {
 				"node": ">= 6"
 			}
-		},
-		"node_modules/glob-to-regexp": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
-			"integrity": "sha512-Iozmtbqv0noj0uDDqoL0zNq0VBEfK2YFoMAZoxJe4cwphvLR+JskfF30QhXHOR4m3KrE6NLRYw+U9MRXvifyig==",
-			"dev": true
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -4764,15 +4619,6 @@
 			"integrity": "sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==",
 			"dev": true
 		},
-		"node_modules/loupe": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-			"integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
-			"dev": true,
-			"dependencies": {
-				"get-func-name": "^2.0.1"
-			}
-		},
 		"node_modules/lru-cache": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -5749,15 +5595,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/pathval": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/peek-readable": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-5.0.0.tgz",
@@ -6030,17 +5867,6 @@
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/Borewit"
-			}
-		},
-		"node_modules/readdir-enhanced": {
-			"version": "1.5.2",
-			"resolved": "https://registry.npmjs.org/readdir-enhanced/-/readdir-enhanced-1.5.2.tgz",
-			"integrity": "sha512-oncAoS9LLjy/+DeZfSAdZBI/iFJGcPCOp44RPFI6FIMHuxt5CC5P0cUZ9mET+EZB9ONhcEvAids/lVRkj0sTHw==",
-			"dev": true,
-			"dependencies": {
-				"call-me-maybe": "^1.0.1",
-				"es6-promise": "^4.1.0",
-				"glob-to-regexp": "^0.3.0"
 			}
 		},
 		"node_modules/readdirp": {
@@ -6347,12 +6173,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/sift": {
-			"version": "17.0.1",
-			"resolved": "https://registry.npmjs.org/sift/-/sift-17.0.1.tgz",
-			"integrity": "sha512-10rmPF5nuz5UdKuhhxgfS7Vz1aIRGmb+kn5Zy6bntCgNwkbZc0a7Z2dUw2Y9wSoRrBzf7Oim81SUsYdOkVnI8Q==",
-			"dev": true
 		},
 		"node_modules/signal-exit": {
 			"version": "3.0.7",

--- a/package.json
+++ b/package.json
@@ -136,8 +136,6 @@
 	"devDependencies": {
 		"@istanbuljs/esm-loader-hook": "^0.2.0",
 		"ava": "^6.1.1",
-		"chai": "^4.4.1",
-		"chai-fs": "^2.0.0",
 		"chokidar-cli": "^3.0.0",
 		"cross-env": "^7.0.3",
 		"depcheck": "^1.4.7",

--- a/test/lib/resources.js
+++ b/test/lib/resources.js
@@ -1,15 +1,23 @@
 import test from "ava";
-import chai from "chai";
-import chaifs from "chai-fs";
-chai.use(chaifs);
-const assert = chai.assert;
 import sinon from "sinon";
+import {readFileSync} from "node:fs";
+
 import {createAdapter, createFilterReader,
 	createFlatReader, createLinkReader, createResource} from "../../lib/resourceFactory.js";
 
 test.afterEach.always((t) => {
 	sinon.restore();
 });
+
+function getFileContent(path) {
+	return readFileSync(path, "utf8");
+}
+
+function fileEqual(t, actual, expected) {
+	const actualContent = getFileContent(actual);
+	const expectedContent = getFileContent(expected);
+	t.is(actualContent, expectedContent);
+}
 
 ["FileSystem", "Memory"].forEach((adapter) => {
 	async function getAdapter(config) {
@@ -51,7 +59,8 @@ test.afterEach.always((t) => {
 
 		t.notThrows(async () => {
 			if (adapter === "FileSystem") {
-				assert.fileEqual(
+				fileEqual(
+					t,
 					"./test/tmp/readerWriters/application.a/simple-read-write/index_readableStreamTest.html",
 					"./test/fixtures/application.a/webapp/index.html");
 			} else {

--- a/test/lib/resources.js
+++ b/test/lib/resources.js
@@ -1,6 +1,6 @@
 import test from "ava";
 import sinon from "sinon";
-import {readFileSync} from "node:fs";
+import {readFile} from "node:fs/promises";
 
 import {createAdapter, createFilterReader,
 	createFlatReader, createLinkReader, createResource} from "../../lib/resourceFactory.js";
@@ -10,12 +10,12 @@ test.afterEach.always((t) => {
 });
 
 function getFileContent(path) {
-	return readFileSync(path, "utf8");
+	return readFile(path, "utf8");
 }
 
-function fileEqual(t, actual, expected) {
-	const actualContent = getFileContent(actual);
-	const expectedContent = getFileContent(expected);
+async function fileEqual(t, actual, expected) {
+	const actualContent = await getFileContent(actual);
+	const expectedContent = await getFileContent(expected);
 	t.is(actualContent, expectedContent);
 }
 
@@ -59,7 +59,7 @@ function fileEqual(t, actual, expected) {
 
 		t.notThrows(async () => {
 			if (adapter === "FileSystem") {
-				fileEqual(
+				await fileEqual(
 					t,
 					"./test/tmp/readerWriters/application.a/simple-read-write/index_readableStreamTest.html",
 					"./test/fixtures/application.a/webapp/index.html");


### PR DESCRIPTION
`chai-fs` is not compatible with latest version of `chai`. Therefore its easier to get rid of chai completely.

JIRA: CPOUI5FOUNDATION-801