### PR TITLE
[BREAKING] DuplexCollection: remove byGlobSource method

### DIFF
--- a/lib/DuplexCollection.js
+++ b/lib/DuplexCollection.js
@@ -56,25 +56,6 @@ class DuplexCollection extends AbstractReaderWriter {
 	}
 
 	/**
-	 * Locates resources by glob from source reader only.
-	 * For found resources that are also available in the writer, the writer resource will be returned.
-	 *
-	 * @param {string} virPattern glob pattern for virtual directory structure
-	 * @param {object} [options] glob options
-	 * @param {boolean} [options.nodir=true] Do not match directories
-	 * @returns {Promise<@ui5/fs/Resource[]>} Promise resolving to list of resources
-	 */
-	byGlobSource(virPattern, options = {nodir: true}) {
-		return this._reader.byGlob(virPattern, options).then((resources) => {
-			return Promise.all(resources.map((readerResource) => {
-				return this._writer.byPath(readerResource.getPath()).then((writerResource) => {
-					return writerResource || readerResource;
-				});
-			}));
-		});
-	}
-
-	/**
 	 * Locates resources by path.
 	 *
 	 * @private

--- a/test/lib/DuplexCollection.js
+++ b/test/lib/DuplexCollection.js
@@ -85,52 +85,6 @@ test("DuplexCollection: _byGlob", async (t) => {
 	t.is(resourceContent, "content", "Resource has expected content");
 });
 
-test("DuplexCollection: _byGlobSource w/o found resources", async (t) => {
-	t.plan(3);
-
-	const abstractReader = {
-		byGlob: sinon.stub().returns(Promise.resolve([]))
-	};
-	const duplexCollection = new DuplexCollection({
-		name: "myCollection",
-		reader: abstractReader,
-		writer: abstractReader
-	});
-	const resources = await duplexCollection.byGlobSource("anyPattern", {someOption: true});
-
-	t.true(Array.isArray(resources), "Found resources are returned as an array");
-	t.true(resources.length === 0, "No resources found");
-	t.true(abstractReader.byGlob.calledWithExactly("anyPattern", {someOption: true}),
-		"Delegated globbing task correctly to readers");
-});
-
-test("DuplexCollection: _byGlobSource with default options and a reader finding a resource", async (t) => {
-	t.plan(3);
-
-	const resource = new Resource({
-		path: "/my/path",
-		buffer: Buffer.from("content")
-	});
-	const abstractReader = {
-		byGlob: sinon.stub().returns(Promise.resolve([resource]))
-	};
-	const abstractWriter = {
-		byPath: sinon.stub().returns(Promise.resolve())
-	};
-	const duplexCollection = new DuplexCollection({
-		name: "myCollection",
-		reader: abstractReader,
-		writer: abstractWriter
-	});
-	const resources = await duplexCollection.byGlobSource("anyPattern");
-
-	t.true(Array.isArray(resources), "Found resources are returned as an array");
-	t.true(abstractReader.byGlob.calledWithExactly("anyPattern", {nodir: true}),
-		"Delegated globbing task correctly to readers");
-	t.true(abstractWriter.byPath.calledWithExactly("/my/path"),
-		"byPath called on writer");
-});
-
 test("DuplexCollection: _byPath with reader finding a resource", async (t) => {
 	t.plan(4);
 


### PR DESCRIPTION
BREAKING CHANGE:
`byGlobSource` method is removed from `DuplexCollection`

JIRA: CPOUI5FOUNDATION-802
Relates to: https://github.com/SAP/ui5-tooling/issues/701