### PR TITLE
[INTERNAL] package.json: Allow npm >= v8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,7 +40,7 @@
 			},
 			"engines": {
 				"node": "^20.11.0 || >=21.2.0",
-				"npm": ">= 10"
+				"npm": ">= 8"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	},
 	"engines": {
 		"node": "^20.11.0 || >=21.2.0",
-		"npm": ">= 10"
+		"npm": ">= 8"
 	},
 	"scripts": {
 		"test": "npm run lint && npm run jsdoc-generate && npm run coverage && npm run depcheck",


### PR DESCRIPTION
There is no actual need to increase the minimum npm version. Lockfile v3 is already supported