### PR TITLE
[FIX] WriterCollection: Handle unmatched paths

### DIFF
--- a/lib/WriterCollection.js
+++ b/lib/WriterCollection.js
@@ -104,12 +104,13 @@ class WriterCollection extends AbstractReaderWriter {
 		const resourcePath = resource.getPath();
 
 		const basePathMatch = resourcePath.match(this._basePathRegex);
-		if (!basePathMatch || basePathMatch.length < 2) {
-			throw new Error(
+		const basePath = basePathMatch?.[1];
+		if (!basePath) {
+			return Promise.reject(new Error(
 				`Failed to find a writer for resource with path ${resourcePath} in WriterCollection ${this._name}. ` +
-				`Base paths handled by this collection are: ${Object.keys(this._writerMapping).join(", ")}`);
+				`Base paths handled by this collection are: ${Object.keys(this._writerMapping).join(", ")}`));
 		}
-		const writer = this._writerMapping[basePathMatch[1]];
+		const writer = this._writerMapping[basePath];
 		return writer._write(resource, options);
 	}
 }

--- a/test/lib/WriterCollection.js
+++ b/test/lib/WriterCollection.js
@@ -148,6 +148,30 @@ test("Write", async (t) => {
 	t.is(generalWriter._write.getCall(0).args[1], "options 3", "Correct write options for / writer");
 });
 
+test("Write: Throws for resource with unmatched path", async (t) => {
+	const myWriter = {
+		_write: sinon.stub()
+	};
+	const writerCollection = new WriterCollection({
+		name: "myCollection",
+		writerMapping: {
+			"/my/app/": myWriter,
+			"/other/": myWriter
+		}
+	});
+
+	const resource = new Resource({
+		path: "/unmatched/resource.js",
+		string: "content"
+	});
+
+	await t.throwsAsync(writerCollection.write(resource), {
+		message: "Failed to find a writer for resource with path /unmatched/resource.js " +
+			"in WriterCollection myCollection. " +
+			"Base paths handled by this collection are: /my/app/, /other/"
+	});
+});
+
 test("byGlob", async (t) => {
 	const myPathWriter = {
 		_byGlob: sinon.stub().resolves([])


### PR DESCRIPTION
This change ensures that a proper error is thrown when attempting to write a resource with a path that does not match any configured base paths.
