### PR TITLE
[INTERNAL] Globby 16 negation only patterns handling

### DIFF
--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -69,8 +69,7 @@ class AbstractAdapter extends AbstractReaderWriter {
 
 		// Append static exclude patterns
 		virPattern = Array.prototype.concat.apply(virPattern, excludes);
-		let patterns = virPattern.map(this._normalizePattern, this);
-		patterns = Array.prototype.concat.apply([], patterns);
+		const patterns = this._normalizePatterns(virPattern);
 		if (patterns.length === 0) {
 			return [];
 		}
@@ -97,6 +96,32 @@ class AbstractAdapter extends AbstractReaderWriter {
 			}
 		}
 		return await this._runGlob(patterns, options, trace);
+	}
+
+	/**
+	 * Normalizes virtual glob patterns and filters out negation-only pattern sets.
+	 *
+	 * @private
+	 * @param {string[]} virPatterns glob patterns for virtual directory structure
+	 * @returns {string[]} A list of normalized glob patterns
+	 */
+	_normalizePatterns(virPatterns) {
+		let patterns = virPatterns.map(this._normalizePattern, this);
+		patterns = Array.prototype.concat.apply([], patterns);
+		if (patterns.length === 0) {
+			return [];
+		}
+
+		// Check if only negation patterns remain (no positive patterns matched this adapter's base path)
+		// This can happen when positive patterns target a different virtual base path
+		// In globby v16+, negation-only patterns get '**/*' prepended, which would match all files
+		// Note: Empty string "" IS a valid positive pattern (matches root directory)
+		const hasPositivePattern = patterns.some((pattern) => !pattern.startsWith("!"));
+		if (!hasPositivePattern) {
+			return [];
+		}
+
+		return patterns;
 	}
 
 	/**

--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -99,32 +99,6 @@ class AbstractAdapter extends AbstractReaderWriter {
 	}
 
 	/**
-	 * Normalizes virtual glob patterns and filters out negation-only pattern sets.
-	 *
-	 * @private
-	 * @param {string[]} virPatterns glob patterns for virtual directory structure
-	 * @returns {string[]} A list of normalized glob patterns
-	 */
-	_normalizePatterns(virPatterns) {
-		let patterns = virPatterns.map(this._normalizePattern, this);
-		patterns = Array.prototype.concat.apply([], patterns);
-		if (patterns.length === 0) {
-			return [];
-		}
-
-		// Check if only negation patterns remain (no positive patterns matched this adapter's base path)
-		// This can happen when positive patterns target a different virtual base path
-		// In globby v16+, negation-only patterns get '**/*' prepended, which would match all files
-		// Note: Empty string "" IS a valid positive pattern (matches root directory)
-		const hasPositivePattern = patterns.some((pattern) => !pattern.startsWith("!"));
-		if (!hasPositivePattern) {
-			return [];
-		}
-
-		return patterns;
-	}
-
-	/**
 	 * Validate if virtual path should be excluded
 	 *
 	 * @param {string} virPath Virtual Path
@@ -220,6 +194,32 @@ class AbstractAdapter extends AbstractReaderWriter {
 			}
 		}
 		return resultGlobs;
+	}
+
+	/**
+	 * Normalizes virtual glob patterns and filters out negation-only pattern sets.
+	 *
+	 * @private
+	 * @param {string[]} virPatterns glob patterns for virtual directory structure
+	 * @returns {string[]} A list of normalized glob patterns
+	 */
+	_normalizePatterns(virPatterns) {
+		let patterns = virPatterns.map(this._normalizePattern, this);
+		patterns = Array.prototype.concat.apply([], patterns);
+		if (patterns.length === 0) {
+			return [];
+		}
+
+		// Check if only negation patterns remain (no positive patterns matched this adapter's base path)
+		// This can happen when positive patterns target a different virtual base path
+		// In globby v16+, negation-only patterns get '**/*' prepended, which would match all files
+		// Note: Empty string "" IS a valid positive pattern (matches root directory)
+		const hasPositivePattern = patterns.some((pattern) => !pattern.startsWith("!"));
+		if (!hasPositivePattern) {
+			return [];
+		}
+
+		return patterns;
 	}
 
 	_createResource(parameters) {

--- a/lib/adapters/AbstractAdapter.js
+++ b/lib/adapters/AbstractAdapter.js
@@ -214,8 +214,8 @@ class AbstractAdapter extends AbstractReaderWriter {
 		// This can happen when positive patterns target a different virtual base path
 		// In globby v16+, negation-only patterns get '**/*' prepended, which would match all files
 		// Note: Empty string "" IS a valid positive pattern (matches root directory)
-		const hasPositivePattern = patterns.some((pattern) => !pattern.startsWith("!"));
-		if (!hasPositivePattern) {
+		const hasOnlyNegativePatterns = patterns.every((pattern) => pattern.startsWith("!"));
+		if (hasOnlyNegativePatterns) {
 			return [];
 		}
 

--- a/test/lib/adapters/AbstractAdapter.js
+++ b/test/lib/adapters/AbstractAdapter.js
@@ -1,4 +1,5 @@
 import test from "ava";
+import sinon from "sinon";
 import AbstractAdapter from "../../../lib/adapters/AbstractAdapter.js";
 import {createResource} from "../../../lib/resourceFactory.js";
 
@@ -301,4 +302,31 @@ test("_normalizePattern: Relative path segment within base directory, matching a
 
 	t.deepEqual(writer._normalizePattern("/path/path2/../**/*"), ["**/*"],
 		"Returned expected patterns");
+});
+
+test("_byGlob: Returns empty array when pattern does not match base path", async (t) => {
+	const adapter = new MyAbstractAdapter({
+		virBasePath: "/test-resources/"
+	});
+	// Mock _runGlob to track if it gets called
+	adapter._runGlob = sinon.stub().resolves([]);
+
+	// Pattern targeting /resources/ should return empty for /test-resources/ adapter
+	const result = await adapter._byGlob(["/resources/**/*.js", "!**/*.support.js"]);
+
+	t.deepEqual(result, [], "Returns empty array");
+	t.is(adapter._runGlob.callCount, 0, "_runGlob should not be called");
+});
+
+test("_byGlob: Handles negation-only patterns after normalization", async (t) => {
+	const adapter = new MyAbstractAdapter({
+		virBasePath: "/test-resources/"
+	});
+	adapter._runGlob = sinon.stub().resolves([]);
+
+	// Only negation patterns - should return empty because there's no positive pattern to match files
+	const result = await adapter._byGlob(["!**/excluded.js"]);
+
+	t.deepEqual(result, [], "Returns empty array for negation-only patterns");
+	t.is(adapter._runGlob.callCount, 0, "_runGlob should not be called for negation-only");
 });

--- a/test/lib/glob.js
+++ b/test/lib/glob.js
@@ -404,3 +404,33 @@ test("glob with multiple patterns with static exclude", async (t) => {
 // 	t.deepEqual(matches.length, 23, "Resources should match");
 // });
 
+// Tests for globby v16 negation-only pattern fix
+test("glob with pattern not matching virtual base path", async (t) => {
+	// This tests the fix for globby v16 negation-only pattern issue
+	// Pattern targets /resources/ but we query from a different base path context
+	const fsAdapter = new FsAdapter({
+		virBasePath: "/test-resources/",
+		fsBasePath: "./test/fixtures/glob"
+	});
+	const resources = await fsAdapter.byGlob([
+		"/resources/**/*.js",
+		"!**/*.support.js"
+	]);
+
+	t.deepEqual(resources, [], "Returns empty array when pattern doesn't match base path");
+});
+
+test("glob with only negation patterns", async (t) => {
+	// Negation-only patterns should not match any files
+	// (In globby v16+, this would otherwise match all files due to auto-prepend of **/*)
+	const fsAdapter = new FsAdapter({
+		virBasePath: "/test-resources/",
+		fsBasePath: "./test/fixtures/glob"
+	});
+	const resources = await fsAdapter.byGlob([
+		"!**/*.json"
+	]);
+
+	t.deepEqual(resources, [], "Returns empty array for negation-only patterns");
+});
+


### PR DESCRIPTION
globby v16.0.0 introduced a breaking change https://github.com/sindresorhus/globby/commit/1273541 that auto-prepends `**/*` when only negation patterns are present.

#### Example reproduction of the issue:
When the minify pattern `["/resources/**/*.js", "!**/*.support.js"]` is normalized for a `[/test-resources/]` adapter:
1 .The positive pattern `[/resources/**/*.js]` is dropped (doesn't match base path)
2. Only `!**/*.support.js` remains
3. globby v16 prepends `**/*` that matches ALL files