### PR TITLE
[FIX] Use structuredClone for Resource.statInfo deep copy

### DIFF
--- a/lib/Resource.js
+++ b/lib/Resource.js
@@ -1,10 +1,26 @@
 import stream from "node:stream";
-import clone from "clone";
 import posixPath from "node:path/posix";
 
 const fnTrue = () => true;
 const fnFalse = () => false;
 const ALLOWED_SOURCE_METADATA_KEYS = ["adapter", "fsPath", "contentModified"];
+
+// Deep-copy an fs.Stats-like object while preserving prototype methods and
+// internal-slot-backed values (Date, Temporal.Instant, Map, Set, typed arrays, …).
+// structuredClone rejects functions (used by synthetic statInfo objects), so
+// function-valued own properties are copied by reference; data values go
+// through structuredClone, which keeps internal slots intact.
+function cloneStatInfo(statInfo) {
+	if (!statInfo || typeof statInfo !== "object") {
+		return statInfo;
+	}
+	const target = Object.create(Object.getPrototypeOf(statInfo));
+	for (const key of Object.getOwnPropertyNames(statInfo)) {
+		const value = statInfo[key];
+		target[key] = typeof value === "function" ? value : structuredClone(value);
+	}
+	return target;
+}
 
 /**
  * Resource. UI5 CLI specific representation of a file's content and metadata
@@ -356,8 +372,8 @@ class Resource {
 	async #getCloneOptions() {
 		const options = {
 			path: this.#path,
-			statInfo: clone(this.#statInfo),
-			sourceMetadata: clone(this.#sourceMetadata)
+			statInfo: cloneStatInfo(this.#statInfo),
+			sourceMetadata: structuredClone(this.#sourceMetadata)
 		};
 
 		if (this.#stream) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@ui5/logger": "^4.0.2",
-				"clone": "^2.1.2",
 				"escape-string-regexp": "^5.0.0",
 				"globby": "^16.2.0",
 				"graceful-fs": "^4.2.11",
@@ -2738,15 +2737,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/wrap-ansi?sponsor=1"
-			}
-		},
-		"node_modules/clone": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
-			"integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8"
 			}
 		},
 		"node_modules/code-excerpt": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,6 @@
 	},
 	"dependencies": {
 		"@ui5/logger": "^4.0.2",
-		"clone": "^2.1.2",
 		"escape-string-regexp": "^5.0.0",
 		"globby": "^16.2.0",
 		"graceful-fs": "^4.2.11",

--- a/test/lib/Resource.js
+++ b/test/lib/Resource.js
@@ -697,3 +697,51 @@ test("integration stat - resource size", async (t) => {
 	resource.setString("myvalue");
 	t.is(await resource.getSize(), 7);
 });
+
+test("Resource: clone preserves prototype methods on real fs.Stats", async (t) => {
+	const fsPath = path.join("test", "fixtures", "application.a", "webapp", "index.html");
+	const statInfo = await fs.stat(fsPath);
+
+	const resource = new Resource({
+		path: "/some/path",
+		statInfo,
+		buffer: Buffer.from("Content")
+	});
+
+	const clonedStat = (await resource.clone()).getStatInfo();
+
+	t.is(typeof clonedStat.isFile, "function", "isFile method preserved on clone");
+	t.true(clonedStat.isFile(), "isFile() returns the expected value");
+	t.true(clonedStat.mtime instanceof Date, "mtime is still a Date");
+	// The original mtime is computed lazily from mtimeMs via a prototype getter.
+	// Both sides should yield the same time without throwing.
+	t.is(clonedStat.mtime.getTime(), statInfo.mtime.getTime(), "mtime time value preserved");
+	// Regression: JSON.stringify must not throw on the cloned stat. On Node 26
+	// fs.Stats exposes Temporal.Instant getters whose toJSON requires the
+	// internal slot — copying those values via a plain `clone` package strips
+	// the slot and breaks JSON.stringify. structuredClone-based copying keeps
+	// the prototype intact and lets the lazy getters compute fresh values.
+	t.notThrows(() => JSON.stringify(clonedStat), "cloned statInfo can be JSON-stringified");
+});
+
+test("Resource: clone deep-copies Date values in synthetic statInfo", async (t) => {
+	const mtime = new Date("2024-01-02T03:04:05Z");
+	const resource = new Resource({
+		path: "/some/path",
+		statInfo: {
+			isFile: () => true,
+			isDirectory: () => false,
+			mtime,
+		},
+		buffer: Buffer.from("Content")
+	});
+
+	const clonedStat = (await resource.clone()).getStatInfo();
+
+	t.true(clonedStat.mtime instanceof Date, "mtime is a Date on the clone");
+	t.not(clonedStat.mtime, mtime, "mtime is a fresh Date instance");
+	t.is(clonedStat.mtime.getTime(), mtime.getTime(), "mtime time value preserved");
+	// Sanity-check that the cloned Date is fully functional (the bug exposed by
+	// the old `clone` package was that Date copies lost their internal slot).
+	t.notThrows(() => clonedStat.mtime.toJSON(), "cloned Date supports toJSON");
+});


### PR DESCRIPTION
The `clone` package recreates internal-slot-backed values like Date and Temporal.Instant as prototype-only copies, stripping the slot. On Node 26 `fs.Stats` exposes Temporal.Instant getters whose `toJSON` performs a strict internal-slot check and throws, breaking any consumer that JSON-stringifies a cloned stat (e.g. `@ui5/builder`'s theme worker IPC).

Replace `clone` with a small helper that preserves the prototype, copies function-valued own properties by reference, and runs each data value through `structuredClone` — which correctly handles Date, Temporal, Map, Set, typed arrays, etc. `sourceMetadata` uses `structuredClone` directly. The unmaintained `clone` dependency is removed.